### PR TITLE
dbus: Cleanup dbus naming for interface / connection / object.

### DIFF
--- a/dist/tpm2-abrmd.conf
+++ b/dist/tpm2-abrmd.conf
@@ -3,13 +3,13 @@
 <busconfig>
   <!-- ../system.conf have denied everything, so we just punch some holes -->
   <policy user="tss">
-    <allow own="com.intel.tss2.Tab"/>
+    <allow own="com.intel.tss2.Tabrmd"/>
   </policy>
   <policy user="root">
-    <allow own="com.intel.tss2.Tab"/>
+    <allow own="com.intel.tss2.Tabrmd"/>
   </policy>
   <policy context="default">
-    <allow send_destination="com.intel.tss2.Tab"/>
-    <allow receive_sender="com.intel.tss2.Tab"/>
+    <allow send_destination="com.intel.tss2.Tabrmd"/>
+    <allow receive_sender="com.intel.tss2.Tabrmd"/>
   </policy>
 </busconfig>

--- a/dist/tpm2-abrmd.service.in
+++ b/dist/tpm2-abrmd.service.in
@@ -1,10 +1,10 @@
 # copy this file into /etc/systemd/system
 [Unit]
-Description=TPM2 Access Broker and Resource Manager
+Description=TPM2 Access Broker and Resource Management Daemon
 
 [Service]
 Type=dbus
-BusName=com.intel.tss2.Tab
+BusName=com.intel.tss2.Tabrmd
 Environment=G_MESSAGES_DEBUG=all
 StandardOutput=syslog
 ExecStart=@SBINDIR@/tpm2-abrmd

--- a/src/include/tabrmd.h
+++ b/src/include/tabrmd.h
@@ -30,9 +30,9 @@
 #include <gio/gio.h>
 #include <tpm20.h>
 
-#define TABRMD_DBUS_INTERFACE                "com.intel.tss2.Tab"
-#define TABRMD_DBUS_NAME                     "com.intel.tss2.Tab"
-#define TABRMD_DBUS_PATH                     "/com/intel/tss2/Tab"
+#define TABRMD_DBUS_INTERFACE                "com.intel.tss2.TctiTabrmd"
+#define TABRMD_DBUS_NAME                     "com.intel.tss2.Tabrmd"
+#define TABRMD_DBUS_PATH                     "/com/intel/tss2/Tabrmd/Tcti"
 #define TABRMD_DBUS_METHOD_CREATE_CONNECTION "CreateConnection"
 #define TABRMD_DBUS_METHOD_CANCEL            "Cancel"
 

--- a/src/tabrmd.xml
+++ b/src/tabrmd.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
   "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name='/com/intel/tss2/TctiTabrmd'>
+<node>
     <interface name='com.intel.tss2.TctiTabrmd'>
         <method name='CreateConnection'>
             <arg type='ah' name='fds' direction='out'/>


### PR DESCRIPTION
This also removes an unused xml attribute from the interface definition.
We can add this back if we fiture out what it was for.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>