### PR TITLE
tabrmd: Add --version option to display version string.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,5 @@
-m4_define([tss2tab_major_version], [0])
-m4_define([tss2tab_minor_version], [1])
-m4_define([tss2tab_version_string], [tss2tab_major_version.tss2tab_minor_version])
-
-AC_INIT([tss2tab], [tss2tab_version_string])
+AC_INIT([tpm2-abrmd],
+        [m4_esyscmd_s([git describe --tags --always --dirty])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 LT_INIT()
@@ -28,7 +25,7 @@ PKG_CHECK_MODULES([SAPI],[sapi])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
 AC_PATH_PROG([GDBUS_CODEGEN], [`$PKG_CONFIG --variable=gdbus_codegen gio-2.0`])
 if test -z "$GDBUS_CODEGEN"; then
-    AC_MSG_ERROR([*** gdbus-codegen is required to build tss2-tabd])
+    AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])
 fi
 # disable helgrind and drd, they hate GAsyncQueue
 AX_VALGRIND_DFLT([sgcheck], [off])

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -63,6 +63,9 @@ is 127.0.0.1.
 \fB\-p,\ \-\-tcti-socket-port\fR
 Specify the port number used by the socket TCTI. The default is 2222.
 \}
+.TP
+\fB\-v,\ \-\-version\fR
+Disply version string.
 .SH ENVIRONMENT
 none
 .SH BUGS

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -573,6 +573,21 @@ init_thread_func (gpointer user_data)
 
     return NULL;
 }
+/*
+ * This is a GOptionArgFunc callback invoked from the GOption processor from
+ * the parse_opts function below. It will be called when the daemon is
+ * invoked with the -v/--version option. This will cause the daemon to
+ * display a version string and exit.
+ */
+gboolean
+show_version (const gchar  *option_name,
+              const gchar  *value,
+              gpointer      data,
+              GError      **error)
+{
+    g_print ("tpm2-abrmd version %s\n", VERSION);
+    exit (0);
+}
 /**
  * This function parses the parameter argument vector and populates the
  * parameter 'options' structure with data needed to configure the tabrmd.
@@ -609,6 +624,8 @@ parse_opts (gint            argc,
         { "max-transient-objects", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
           &options->max_transient_objects,
           "Maximum number of loaded transient objects per client." },
+        { "version", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+          show_version, "Show version string" },
         { NULL },
     };
 


### PR DESCRIPTION
This borrows heavily from the version string mechanism used in the
tpm2.0-tools project.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>