### PR TITLE
tabrmd-priv: Define G_OPTION_FLAG_NONE if not already defined.

### DIFF
--- a/src/tabrmd-priv.h
+++ b/src/tabrmd-priv.h
@@ -34,6 +34,10 @@
 #define TABD_INIT_THREAD_NAME "tss2-tabrmd_init-thread"
 #define TABD_RAND_FILE "/dev/random"
 
+#ifndef G_OPTION_FLAG_NONE
+#define G_OPTION_FLAG_NONE 0
+#endif
+
 typedef struct tabrmd_options {
     GBusType        bus;
     TctiOptions    *tcti_options;


### PR DESCRIPTION
This constant is defined in glib-2.0 versions >= 2.42. Travis CI
packages a super old version of Ubuntu that provides glib-2.0 version
2.40. So we define this ourselves if it's not already defined for us.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>