### PR TITLE
tpm2-abrmd.8.in: Fix bad default port number for socket TCTI.

### DIFF
--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -61,7 +61,7 @@ Specify the domain name or IP address used by the socket TCTI. The default
 is 127.0.0.1.
 .TP
 \fB\-p,\ \-\-tcti-socket-port\fR
-Specify the port number used by the socket TCTI. The default is 2222.
+Specify the port number used by the socket TCTI. The default is 2321.
 \}
 .TP
 \fB\-v,\ \-\-version\fR


### PR DESCRIPTION
The default port number used by the simulator is 2321. This is the
default port used by the tpm2-abrmd. The man page was wrong though.
Fixed! See
https://github.com/flihp/tpm2-abrmd/commit/267ec43bddd59c50af3277ae49b9b601423aa4e9#commitcomment-22170495

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>