### PR TITLE
test: Fixup unit tests for ResourceManager and Tpm2Response.

### DIFF
--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -358,6 +358,7 @@ resource_manager_load_contexts_test (void **state)
     HandleMapEntry *entry;
     GSList         *entry_slist;
     HandleMap      *map;
+    SessionList    *loaded_sessions;
     TPM_HANDLE      phandles [2] = {
         HR_TRANSIENT + 0xeb,
         HR_TRANSIENT + 0xbe,
@@ -380,16 +381,19 @@ resource_manager_load_contexts_test (void **state)
         handle_map_insert (map, vhandles [i], entry);
         g_object_unref (entry);
     }
+    loaded_sessions = session_list_new (50);
     g_debug ("before resource_manager_load_contexts");
     rc = resource_manager_load_contexts (data->resource_manager,
                                          data->command,
-                                         &entry_slist);
+                                         &entry_slist,
+                                         loaded_sessions);
     g_debug ("after resource_manager_load_contexts");
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     for (i = 0; i < handle_count; ++i) {
         handle_ret = tpm2_command_get_handle (data->command, i);
         assert_int_equal (phandles [i], handle_ret);
     }
+    g_object_unref (loaded_sessions);
 }
 int
 main (int   argc,

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -31,6 +31,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#include "tpm2-header.h"
 #include "tpm2-response.h"
 
 #define HANDLE_TEST 0xdeadbeef
@@ -94,6 +95,7 @@ tpm2_response_setup_with_handle (void **state)
     data->response = tpm2_response_new (data->connection,
                                         data->buffer,
                                         attributes);
+    set_response_size (data->buffer, TPM_HEADER_SIZE + sizeof (TPM_HANDLE));
     data->buffer [TPM_RESPONSE_HEADER_SIZE]     = 0xde;
     data->buffer [TPM_RESPONSE_HEADER_SIZE + 1] = 0xad;
     data->buffer [TPM_RESPONSE_HEADER_SIZE + 2] = 0xbe;


### PR DESCRIPTION
Failures were caused by minor changes made in the run up to the
1.0.0 release.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>