### PR TITLE
Unit fixup

### DIFF
--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -272,6 +272,7 @@ access_broker_lock_test (void **state)
     sleep (1);
     assert_false (data->acquired_lock);
     assert_int_equal (access_broker_unlock (data->broker), 0);
+    pthread_join (thread_id, NULL);
 }
 /**
  * Here we're testing the internals of the 'access_broker_send_command'

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -155,8 +155,7 @@ resource_manager_setup_two_transient_handles (void **state)
 
     /* create Tpm2Command that we'll be transforming */
     buffer = calloc (1, TPM_HEADER_SIZE + 2 * sizeof (TPM_HANDLE));
-    buffer [0]  = 0x80;
-    buffer [1]  = 0x02;
+    *(TPM_ST*)buffer = htobe16 (TPM_ST_NO_SESSIONS);
     buffer [2]  = 0x00;
     buffer [3]  = 0x00;
     buffer [4]  = 0x00;


### PR DESCRIPTION
Fixes unclaimed thread resources and an out of bounds read caused by a bad tpm command tag. These are just in the unit tests and were uncovered by valgrind.