### PR TITLE
Check valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - libcmocka-dev
       - libglib2.0-dev
       - libdbus-1-dev
+      - valgrind
 
 install:
   - git clone https://github.com/01org/TPM2.0-TSS.git
@@ -31,11 +32,12 @@ before_script:
 script :
   - mkdir ./build
   - pushd ./build
-  - ../configure --enable-unit --sysconfdir=/etc
+  - ../configure --enable-unit --enable-valgrind --sysconfdir=/etc
   - make -j$(nproc)
   - sudo make install
-  - make -j$(nproc) check
+  - make check-valgrind
   - |
+    cat test-suite*.log
     for LOG in $(ls -1 test/*.log); do
         echo "${LOG}"
         cat ${LOG}

--- a/Makefile.am
+++ b/Makefile.am
@@ -110,7 +110,7 @@ endif # HAVE_SYSTEMD
 
 @VALGRIND_CHECK_RULES@
 VALGRIND_G_DEBUG = fatal-criticals,gc-friendly
-VALGRIND_memcheck_FLAGS = --show-leak-kinds=definite,indirect --track-origins=yes
+VALGRIND_memcheck_FLAGS = --leak-check=summary --show-leak-kinds=definite,indirect --track-origins=yes
 
 # utility library with most of the code that makes up the daemon
 src_libutil_la_LIBADD  = $(DBUS_LIBS) $(GIO_LIBS) $(GLIB_LIBS) $(PTHREAD_LIBS) \

--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -206,7 +206,7 @@ VALGRIND_LOG_COMPILER = \
 	$(valgrind_lt) \
 	$(VALGRIND) $(VALGRIND_SUPPRESSIONS) --error-exitcode=1 $(VALGRIND_FLAGS)
 
-define valgrind_tool_rule =
+define valgrind_tool_rule
 check-valgrind-$(1):
 ifeq ($$(VALGRIND_ENABLED)-$$(ENABLE_VALGRIND_$(1)),yes-yes)
 	$$(valgrind_v_use)$$(MAKE) check-TESTS \

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -213,19 +213,6 @@ resource_manager_type_test (void **state)
     assert_true (IS_RESOURCE_MANAGER (data->resource_manager));
 }
 /**
- * A test: Ensure that the thread in the resource manager behaves as a
- * thread should.
- */
-static void
-resource_manager_thread_lifecycle_test (void **state)
-{
-    test_data_t *data = (test_data_t*)*state;
-
-    assert_int_equal (thread_start  (THREAD (data->resource_manager)), 0);
-    assert_int_equal (thread_cancel (THREAD (data->resource_manager)), 0);
-    assert_int_equal (thread_join   (THREAD (data->resource_manager)), 0);
-}
-/**
  * A test: Ensure that the Sink interface to the ResourceManager works. We
  * create a Tpm2Command, send it through the ResourceManager enqueue
  * function then pull it out the other end by reaching in to the
@@ -400,9 +387,6 @@ main (int   argc,
 {
     const UnitTest tests[] = {
         unit_test_setup_teardown (resource_manager_type_test,
-                                  resource_manager_setup,
-                                  resource_manager_teardown),
-        unit_test_setup_teardown (resource_manager_thread_lifecycle_test,
                                   resource_manager_setup,
                                   resource_manager_teardown),
         unit_test_setup_teardown (resource_manager_sink_enqueue_test,

--- a/test/response-sink_unit.c
+++ b/test/response-sink_unit.c
@@ -45,53 +45,12 @@ response_sink_allocate_test (void **state)
     g_object_unref (sink);
 }
 
-/* response_sink_start_stop_test begin
- */
-typedef struct start_stop_data {
-    ResponseSink  *sink;
-} start_stop_data_t;
-
-static void
-response_sink_start_stop_test (void **state)
-{
-    start_stop_data_t *data = (start_stop_data_t*)*state;
-    gint ret = 0;
-
-    ret = thread_start (THREAD (data->sink));
-    assert_int_equal (ret, 0);
-    ret = thread_cancel (THREAD (data->sink));
-    assert_int_equal (ret, 0);
-    ret = thread_join (THREAD (data->sink));
-    assert_int_equal (ret, 0);
-}
-static void
-response_sink_start_stop_setup (void **state)
-{
-    start_stop_data_t *data = calloc (1, sizeof (start_stop_data_t));
-
-    data->sink = response_sink_new ();
-
-    *state = data;
-}
-static void
-response_sink_start_stop_teardown (void **state)
-{
-    start_stop_data_t *data = (start_stop_data_t*)*state;
-
-    g_object_unref (data->sink);
-    g_free (data);
-}
-/* response_sink_start_stop end */
-
 int
 main (int argc,
       char* argv[])
 {
     const UnitTest tests[] = {
         unit_test (response_sink_allocate_test),
-        unit_test_setup_teardown (response_sink_start_stop_test,
-                                  response_sink_start_stop_setup,
-                                  response_sink_start_stop_teardown),
     };
     return run_tests (tests);
 }


### PR DESCRIPTION
This series enables valgrind so that `make check-valgrind` runs the unit tests under the valgrind memcheck memory profiler. There are two unit tests, both exercising the Thread lifecycle for derived classes, that had to be removed. These tests both cause a 'critical' error to be thrown up by glib 2.40. They weren't good / valid tests anyways and they should be re-written.