### PR TITLE
TctiOptions: Remove final remnants of the EchoTcti.

### DIFF
--- a/src/tcti-options.h
+++ b/src/tcti-options.h
@@ -48,7 +48,6 @@ typedef struct _TctiOptions
     gchar           *device_name;
     gchar           *socket_address;
     guint            socket_port;
-    guint            echo_size;
 } TctiOptions;
 
 #define TYPE_TCTI_OPTIONS             (tcti_options_get_type       ())


### PR DESCRIPTION
The EchoTcti was some old debugging infrastructure. It was cleaned out
of the daemon a long time back. We still use it in a few test cases so
the code is still around. It's not used in the tpm2-abrmd though.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>