### PR TITLE
tabrmd: Instantiate the TctiOptions object in main, not parse_opts.

### DIFF
--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -629,8 +629,6 @@ parse_opts (gint            argc,
         { NULL },
     };
 
-    g_debug ("creating tcti_options object");
-    options->tcti_options = tcti_options_new ();
     ctx = g_option_context_new (" - TPM2 software stack Access Broker Daemon (tabrmd)");
     g_option_context_add_main_entries (ctx, entries, NULL);
     g_option_context_add_group (ctx, tcti_options_get_group (options->tcti_options));
@@ -685,6 +683,8 @@ main (int argc, char *argv[])
     GThread *init_thread;
 
     g_info ("tabrmd startup");
+    /* instantiate a TctiOptions object for the parse_opts function to use */
+    gmain_data.options.tcti_options = tcti_options_new ();
     parse_opts (argc, argv, &gmain_data.options);
     gmain_data.tcti = tcti_options_get_tcti (gmain_data.options.tcti_options);
 


### PR DESCRIPTION
The TctiOptions object was instantiated as a side effect of the
parse_opts function. It gets used in the main function immediately after
the call to parse_opts (where the TCTI is instantiated).

It's better form to instantiate this object in main. Then it's passed
into the parse_opts function where the TCTI options are parsed. Then we
use it as a factory to pump out a Tcti object based on the parsed
options.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>