### PR TITLE
Fixes from clang static analyzer

### DIFF
--- a/src/session-list.c
+++ b/src/session-list.c
@@ -180,7 +180,7 @@ session_list_insert (SessionList      *list,
 {
     g_debug ("session_list_insert: 0x%" PRIxPTR ", entry: 0x%" PRIxPTR,
              (uintptr_t)list, (uintptr_t)entry);
-    if (list == NULL && entry == NULL) {
+    if (list == NULL || entry == NULL) {
         g_error ("session_list_insert passed NULL parameter");
     }
     session_list_lock (list);

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -180,6 +180,7 @@ sapi_init_from_tcti_ctx (TSS2_TCTI_CONTEXT *tcti_ctx)
     rc = Tss2_Sys_Initialize (sapi_ctx, size, tcti_ctx, &abi_version);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to initialize SAPI context: 0x%x\n", rc);
+	free (sapi_ctx);
         return NULL;
     }
     return sapi_ctx;


### PR DESCRIPTION
This patchset fixes some minor findings from clang's scan-build.