### PR TITLE
configure.ac: Use hard coded systemd unit dir not pkgconfig variable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_ARG_WITH([systemdsystemunitdir],
             AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
                            [Directory for systemd service files]),
             [],
-            [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+            [with_systemdsystemunitdir=${libdir}/systemd/system])
 AS_IF([test "x$with_systemdsystemunitdir" != xno],
       [AC_SUBST([systemdsystemunitdir],
       [$with_systemdsystemunitdir])])


### PR DESCRIPTION
Querying pkg-config for the default here made sense at the time but it
breaks distcheck. This is because distcheck does a DESTDIR install and
the default ignores this.

After thinking about this a bit I'm realizing that using pkg-config also
causes "non-standard" behavior in that it will ignore the expected
behavior when overriding ${libdir}.

This patch simplifies this abit defaulting to ${libdir}/systemd/system.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>