### PR TITLE
ResourceManager: If command has wrong code return NULL;

### DIFF
--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -457,7 +457,7 @@ resource_manager_flush_context (ResourceManager *resmgr,
 
     if (tpm2_command_get_code (command) != TPM_CC_FlushContext) {
         g_warning ("resource_manager_flush_context with wrong command");
-        return TSS2_RC_SUCCESS;
+        return NULL;
     }
     handle = tpm2_command_get_flush_handle (command);
     g_debug ("resource_manager_flush_context handle: 0x%" PRIx32, handle);


### PR DESCRIPTION
This is an exceptional condition that shouldn't happen. But if it does
we return NULL (not an RC) and the ResourceManager will carry on
processing the command like any other.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>