### PR TITLE
travis: Run 'make check' and dump logs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ script :
   - ../configure --enable-unit --enable-valgrind --sysconfdir=/etc
   - make -j$(nproc)
   - sudo make install
+  - make check
+  - |
+    cat test-suite*.log
+    for LOG in $(ls -1 test/*.log); do
+        echo "${LOG}"
+        cat ${LOG}
+    done
   - make check-valgrind
   - |
     cat test-suite*.log


### PR DESCRIPTION
We're currently running 'make check-valgrind' which only returns an
error code if memcheck detects errors in the unit test. If the unit test
itself fails however memcheck will not indicate a failure. So we need to
run both 'make check' to detect failures in the unit tests, and then
'make check-valgrind' to get errors detected by memcheck.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>