### PR TITLE
build: Integrate distcheck into travis, enable unit tests for distcheck.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,9 @@ before_script:
   - ./bootstrap
 
 script :
-  - mkdir ./build
-  - pushd ./build
-  - ../configure --enable-unit --enable-valgrind --sysconfdir=/etc
-  - make -j$(nproc)
-  - sudo make install
-  - make check
-  - |
-    cat test-suite*.log
-    for LOG in $(ls -1 test/*.log); do
-        echo "${LOG}"
-        cat ${LOG}
-    done
-  - make check-valgrind
+  - ./configure --enable-unit --enable-valgrind
+  - make -j$(nproc) distcheck
+  - make -j$(nproc) check-valgrind
   - |
     cat test-suite*.log
     for LOG in $(ls -1 test/*.log); do

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,10 @@ AC_PROG_CC
 LT_INIT()
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_FILES([Makefile])
+
+# propagate configure arguments to distcheck
+AC_SUBST([DISTCHECK_CONFIGURE_FLAGS],[$ac_configure_args])
+
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AC_ARG_ENABLE([unit],
               [AS_HELP_STRING([--enable-unit],


### PR DESCRIPTION
By running distcheck we get a full test of the VPATH build stuff, all of
the packaging checks and a run of 'make check' for all of our unit
tests. The only thing distcheck won't do for us (or at least I don't
know how to get it to do this) is to run 'check-valgrind'. So we still
have to do a build manually and run 'check-valgrind'.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>