### PR TITLE
Coverity scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,22 @@ addons:
       - libglib2.0-dev
       - libdbus-1-dev
       - valgrind
+  coverity_scan:
+    project:
+      name: 01org/tpm2-abrmd
+      description: Build submitted via Travis-CI
+    notification_email: flihp@twobit.us
+    build_command_prepend: "./configure; make clean"
+    build_command: "make -j$(nproc)"
+    branch_pattern: coverity_scan
+
+env:
+  global:
+    # COVERITY_SCAN_TOKEN created by coverity using 'travis encrypt' using
+    # project repo public key
+    - secure: "hWep+zj8S3ahEGUpOaFbsHVqJ/1Gpf7+4Vos0Op1jyCF0Iw3r/MRxC1AABhxOjPhlNNf9q19b0IjVzVWh+owiFItK/NCgNG+daSuCk945F5tREYKFui+b9JrLMGx8+zfrL+KAy3BVDUUobLrh7vBTdbr9Wg4Kbryt6lBh0wpPnbMqCuUKEwAYw8K9YpoviqGdW1AWwWEpApoXtjukiF3Virc+sfRN/3xpDpHyc7LESzREE/xkZe879e1pFGLys7perOf2JhgKdj0B0otQXPcPuoB8ppFsxTQwbZbcfpZW/l7Vo6aUjmoXw6+DTZK+skne2K9uCP2gjuVwLnkzgBhX8OYVyHscmA+xl0wLIwkTkPcW76bfOVZPkgaKGdKBW7mdl2Tk8DBZfF10XZ0zSLAOEwUeYkIr4vc4ybGRcw9xS6ixXeENzW9BR1NUktSdQBrMSYnrRvDQkEKiUpd7f4uFOKQT0evvjvAI8rXEcC5eo8ODJYHni0Zep/c/rKEPduUsZgZQ18F86q/G3DtIl+69/gDEEUKnDXSFejFfzO+NGWp+jL5aybE0pjzXsiLmwklDiY6po+dgkiTbL3SKlMl8a+miteNu2fgar8D443afGiHABUpiRwNYN/47WombgYst5ZcnnDFmUIYa7SYoxZAeCsCTySdyTso02POFAKYz5U="
+    # run coverity scan on gcc build to keep from DOSing coverity
+    - coverity_scan_run_condition='"$CC" = gcc'
 
 install:
   - git clone https://github.com/01org/TPM2.0-TSS.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/01org/tpm2-abrmd.svg?branch=master)](https://travis-ci.org/01org/tpm2-abrmd)
+[![Coverity Scan](https://img.shields.io/coverity/scan/3997.svg)](https://scan.coverity.com/projects/01org-tpm2-abrmd)
 
 # TPM2 Access Broker & Resource Manager
 This is a system daemon implementing the TPM2 access broker (TAB) & Resource

--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -331,6 +331,7 @@ TSS2_SYS_CONTEXT*
 access_broker_lock_sapi (AccessBroker *broker)
 {
     access_broker_lock (broker);
+    g_assert_nonnull (broker->sapi_context);
     return broker->sapi_context;
 }
 /*

--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -530,8 +530,8 @@ access_broker_get_trans_object_count (AccessBroker *broker,
     TPMI_YES_NO more_data;
     TPMS_CAPABILITY_DATA capability_data = { 0, };
 
-    if (broker == NULL || count == NULL)
-        g_error ("get_loaded_transient_object_count: got NULL parameter");
+    g_assert_nonnull (broker);
+    g_assert_nonnull (count);
     sapi_context = access_broker_lock_sapi (broker);
     /*
      * GCC gets confused by the TRANSIENT_FIRST constant being used for the

--- a/src/command-attrs.c
+++ b/src/command-attrs.c
@@ -94,6 +94,7 @@ command_attrs_init_tpm (CommandAttrs *attrs,
     sapi_context = access_broker_lock_sapi (broker);
     if (sapi_context == NULL) {
         g_warning ("access_broker_lock_sapi returned NULL TSS2_SYS_CONTEXT.");
+        access_broker_unlock (broker);
         return -1;
     }
     g_debug ("GetCapabilty for 0x%" PRIx32 " commands", attrs->count);


### PR DESCRIPTION
Enable automated static analysis on the 'coverity_scan' branch. This includes a few fixups necessary to keep coverity from having a heart attack. There are still a few items to fix in the test code but everything under `src/` got a clean bill of health.