### PR TITLE
Tss2 tcti tabrmd init full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
 
 ## Unreleased
 ### Added
+- Environment variables TABRMD_TEST_BUS_TYPE and TABRMD_TEST_BUS_NAME to
+control D-Bus type and name selection respectively in the integration test
+harness.
 - tss2_tcti_tabrmd_init_full function to libtcti-tabrmd to allow for selection
 of D-Bus bus type and name used by tpm2-abrmd instance.
 - Command line option --dbus-name to control the name claimed by the daemon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
+
+## Unreleased
+### Added
+- Command line option --dbus-name to control the name claimed by the daemon
+on the D-Bus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,7 @@ The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
 
 ## Unreleased
 ### Added
+- tss2_tcti_tabrmd_init_full function to libtcti-tabrmd to allow for selection
+of D-Bus bus type and name used by tpm2-abrmd instance.
 - Command line option --dbus-name to control the name claimed by the daemon
 on the D-Bus.

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,10 @@ man7_MANS = man/man7/tcti-tabrmd.7
 man8_MANS = man/man8/tpm2-abrmd.8
 TESTS = $(check_PROGRAMS)
 
+install-data-hook:
+	$(LN_S) tss2_tcti_tabrmd_init.3 \
+                $(DESTDIR)$(mandir)/man3/tss2_tcti_tabrmd_init_full.3
+
 tpm2_abrmddir      = $(includedir)/tss2
 tpm2_abrmd_HEADERS = $(srcdir)/src/include/tabrmd.h
 libtcti_tabrmddir      = $(includedir)/tcti

--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,7 @@ test_integration_libtest_la_SOURCES = \
 src_libtcti_tabrmd_la_LIBADD   = $(DBUS_LIBS) $(GIO_LIBS) $(GLIB_LIBS) \
     $(PTHREAD_LIBS) $(noinst_LTLIBRARIES) $(SAPI_LIBS)
 src_libtcti_tabrmd_la_LDFLAGS = -fPIC -Wl,--no-undefined -Wl,--version-script=$(srcdir)/src/tcti-tabrmd.map
-src_libtcti_tabrmd_la_SOURCES = src/tcti-tabrmd.c src/tcti-tabrmd-priv.h
+src_libtcti_tabrmd_la_SOURCES = src/tcti-tabrmd.c src/tcti-tabrmd-priv.h $(srcdir)/src/tcti-tabrmd.map
 
 src_libtcti_echo_la_LIBADD  = $(DBUS_LIBS) $(GLIB_LIBS)
 src_libtcti_echo_la_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([tpm2-abrmd],
         [m4_esyscmd_s([git describe --tags --always --dirty])])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
+AC_PROG_LN_S
 LT_INIT()
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_FILES([Makefile])

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -37,6 +37,10 @@ Set an upper bound on the number of transient objects that each client
 connection allowed to load. Once this number of objects is reached attempts
 to load new transient objects will produce an error.
 .TP
+\fB\-n,\ \-\-dbus-name\fR
+Claim the given name on dbus. This option overrides the default of
+com.intel.tss2.Tabrmd.
+.TP
 \fB\-s,\ \-\-session\fR
 Connect daemon to the session dbus. This option overrides the default
 behavior.

--- a/man/tss2_tcti_tabrmd_init.3.in
+++ b/man/tss2_tcti_tabrmd_init.3.in
@@ -3,16 +3,22 @@
 .\"
 .TH TSS2_TCTI_TABRMD_INIT 3 "MAY 2017" Intel "TPM2 Software Stack"
 .SH NAME
-tss2_tcti_tabrmd_init \- Initialization function for the tpm2-abrmd TCTI library.
+tss2_tcti_tabrmd_init, tss2_tcti_tabrmd_init_full \- Initialization functions
+for the tpm2-abrmd TCTI library.
 .SH SYNOPSIS
+The
+.BR tss2_tcti_tabrmd_init ()
+and
+.BR tss2_tcti_tabrmd_init_full ()
+functions are used to initialize a TCTI context for communication with the
+.BR tpm2-abrmd (8).
+.sp
 .B #include <tcti/tcti-tabrmd.h>
 .sp
 .BI "TSS2_RC tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT " "*tcti_context" ", size_t " "*size" );
 .sp
-The 
-.BR tss2_tcti_tabrmd_init ()
-function initializes a TCTI context used to communicate with the
-.BR tpm2-abrmd.
+.BI "TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT " "*tcti_context" ", size_t " "*size" ", GBusType" "bus_type" ", const char" "*bus_name" );
+.sp
 .SH DESCRIPTION
 .BR tss2_tcti_tabrmd_init ()
 attempts to initialize a caller allocated
@@ -52,7 +58,9 @@ function in the section titled
 Once initialized, the TCTI context returned exposes the Trusted Computing
 Group (TCG) defined API for the lowest level communication with the TPM.
 Using this API the caller can exchange (send / receive) TPM2 command and
-respons buffers with the tpm2-abrmd. In nearly all cases however, the caller
+respons buffers with the
+.B tpm2-abrmd (8).
+In nearly all cases however, the caller
 will initialize a context using this funnction before passing the context to
 a higher level API like the System API (SAPI), and then never touch it again.
 .sp
@@ -60,9 +68,24 @@ For a more thorough discussion of the TCTI API see the \*(lqTSS System Level
 API and TPM Command Transmission Interface Specification\*(rq specification
 as published by the TCG:
 \%https://trustedcomputinggroup.org/tss-system-level-api-tpm-command-transmission-interface-specification/
+.sp
+.B tss2_tcti_tabrmd_init_full ()
+behaves in the same way as
+.B tss2_tcti_tabrmd_init ()
+but allows for greater flexibility through two additional parameters: The
+.I bus_type
+and
+.I bus_name
+parameters may be used to select which D-Bus bus type and name used to connect
+to an instance of the
+.B tpm2-abrmd (8)
+daemon.
+
 .SH RETURN VALUE
 A successful call to
-.BR tss2_tcti_tabrmd ()
+.BR tss2_tcti_tabrmd_init ()
+and
+.BR tss2_tcti_tabrmd_init_full ()
 will return
 .B TSS2_RC_SUCCESS.
 An unsuccessful call will produce a response code described in section
@@ -73,10 +96,16 @@ is returned if both the
 .I tcti_context
 and the
 .I size
-parameters are NULL.
+parameters are NULL, or the
+.I bus_name
+is NULL, or the
+.I bus_type
+is not a supported type (G_BUS_TYPE_SYSTEM OR G_BUS_TYPE_SESSION).
 .sp
-All errors caused by communication failures with the tpm2-abrmd are treated
-as fatal errors and will call the calling application to terminate.
+All errors caused by communication failures with the
+.B tpm2-abrmd (8)
+are treated as fatal errors and will call the calling application to terminate.
+
 .SH EXAMPLE
 .nf
 #include <inttypes.h>

--- a/src/include/tabrmd.h
+++ b/src/include/tabrmd.h
@@ -31,10 +31,11 @@
 #include <tpm20.h>
 
 #define TABRMD_DBUS_INTERFACE                "com.intel.tss2.TctiTabrmd"
-#define TABRMD_DBUS_NAME                     "com.intel.tss2.Tabrmd"
+#define TABRMD_DBUS_NAME_DEFAULT             "com.intel.tss2.Tabrmd"
 #define TABRMD_DBUS_PATH                     "/com/intel/tss2/Tabrmd/Tcti"
 #define TABRMD_DBUS_METHOD_CREATE_CONNECTION "CreateConnection"
 #define TABRMD_DBUS_METHOD_CANCEL            "Cancel"
+#define TABRMD_DBUS_TYPE_DEFAULT             G_BUS_TYPE_SYSTEM
 
 /* implementation specific RCs */
 #define TSS2_RESMGR_RC_INTERNAL_ERROR (TSS2_RC)(TSS2_RESMGR_ERROR_LEVEL | (1 << TSS2_LEVEL_IMPLEMENTATION_SPECIFIC_SHIFT))

--- a/src/include/tcti-tabrmd.h
+++ b/src/include/tcti-tabrmd.h
@@ -31,10 +31,20 @@
 extern "C" {
 #endif
 
+#include <gio/gio.h>
 #include <sapi/tpm20.h>
 #include <sapi/tss2_tcti.h>
 
+#include "tabrmd.h"
+
+#define TCTI_TABRMD_DBUS_TYPE_DEFAULT TABRMD_DBUS_TYPE_DEFAULT
+#define TCTI_TABRMD_DBUS_NAME_DEFAULT TABRMD_DBUS_NAME_DEFAULT
+
 TSS2_RC tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT *context, size_t *size);
+TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT *context,
+                                    size_t            *size,
+                                    GBusType           bus,
+                                    const char        *name);
 
 #ifdef __cplusplus
 }

--- a/src/tabrmd-priv.h
+++ b/src/tabrmd-priv.h
@@ -40,6 +40,7 @@ typedef struct tabrmd_options {
     gboolean        fail_on_loaded_trans;
     guint           max_connections;
     guint           max_transient_objects;
+    gchar          *dbus_name;
 } tabrmd_options_t;
 
 #endif /* TABRMD_PRIV_H */

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -463,7 +463,7 @@ init_thread_func (gpointer user_data)
     sigaction (SIGTERM, &action, NULL);
 
     data->dbus_name_owner_id = g_bus_own_name (data->options.bus,
-                                               TABRMD_DBUS_NAME,
+                                               data->options.dbus_name,
                                                G_BUS_NAME_OWNER_FLAGS_NONE,
                                                on_bus_acquired,
                                                on_name_acquired,
@@ -610,8 +610,12 @@ parse_opts (gint            argc,
 
     options->max_connections = MAX_CONNECTIONS_DEFAULT;
     options->max_transient_objects = MAX_TRANSIENT_OBJECTS_DEFAULT;
+    options->dbus_name = TABRMD_DBUS_NAME_DEFAULT;
 
     GOptionEntry entries[] = {
+        { "dbus-name", 'n', 0, G_OPTION_ARG_STRING, &options->dbus_name,
+          "Name for daemon to \"own\" on the D-Bus",
+          TABRMD_DBUS_NAME_DEFAULT },
         { "logger", 'l', 0, G_OPTION_ARG_STRING, &logger_name,
           "The name of desired logger, stdout is default.", "[stdout|syslog]"},
         { "session", 's', 0, G_OPTION_ARG_NONE, &session_bus,

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -435,7 +435,7 @@ tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT *context,
         tcti_tabrmd_proxy_new_for_bus_sync (
             G_BUS_TYPE_SYSTEM,
             G_DBUS_PROXY_FLAGS_NONE,
-            TABRMD_DBUS_NAME,              /* bus name */
+            TABRMD_DBUS_NAME_DEFAULT,
             TABRMD_DBUS_PATH, /* object */
             NULL,                          /* GCancellable* */
             &error);

--- a/src/tcti-tabrmd.map
+++ b/src/tcti-tabrmd.map
@@ -1,6 +1,7 @@
 {
     global:
         tss2_tcti_tabrmd_init;
+        tss2_tcti_tabrmd_init_full;
         tss2_tcti_tabrmd_dump_trans_state;
     local:
         *;

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -124,13 +124,14 @@ tcti_socket_init (char const *address,
  * Initialize a TCTI context for the tabrmd. Currently it requires no options.
  */
 TSS2_TCTI_CONTEXT*
-tcti_tabrmd_init (void)
+tcti_tabrmd_init (GBusType    bus_type,
+                  const char *bus_name)
 {
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_ctx;
     size_t size;
 
-    rc = tss2_tcti_tabrmd_init (NULL, &size);
+    rc = tss2_tcti_tabrmd_init_full (NULL, &size, bus_type, bus_name);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to get allocation size for tabrmd TCTI "
                  " context: 0x%" PRIx32 "\n", rc);
@@ -142,7 +143,7 @@ tcti_tabrmd_init (void)
                  strerror (errno));
         return NULL;
     }
-    rc = tss2_tcti_tabrmd_init (tcti_ctx, &size);
+    rc = tss2_tcti_tabrmd_init_full (tcti_ctx, &size, bus_type, bus_name);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to initialize tabrmd TCTI context: "
                  "0x%" PRIx32 "\n", rc);
@@ -222,7 +223,8 @@ tcti_init_from_opts (test_opts_t *options)
                                  options->socket_port);
 #endif
     case TABRMD_TCTI:
-        return tcti_tabrmd_init ();
+        return tcti_tabrmd_init (options->tabrmd_bus_type,
+                                 options->tabrmd_bus_name);
     default:
         return NULL;
     }

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -27,6 +27,7 @@
 #include <glib.h>
 #include <stdbool.h>
 
+#include "tcti-tabrmd.h"
 #include "test.h"
 #include "test-options.h"
 #include "context-util.h"
@@ -49,6 +50,8 @@ main (int   argc,
         .device_file    = DEVICE_PATH_DEFAULT,
         .socket_address = HOSTNAME_DEFAULT,
         .socket_port    = PORT_DEFAULT,
+        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
+        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
     };
 
     get_test_opts_from_env (&opts);

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -27,6 +27,7 @@
 #ifndef TEST_OPTIONS_H
 #define TEST_OPTIONS_H
 
+#include <gio/gio.h>
 #include "sapi/tpm20.h"
 
 /* Default TCTI */
@@ -45,7 +46,8 @@
 #define ENV_DEVICE_FILE    "TPM2OTEST_DEVICE_FILE"
 #define ENV_SOCKET_ADDRESS "TPM20TEST_SOCKET_ADDRESS"
 #define ENV_SOCKET_PORT    "TPM20TEST_SOCKET_PORT"
-
+#define ENV_TABRMD_BUS_TYPE "TABRMD_TEST_BUS_TYPE"
+#define ENV_TABRMD_BUS_NAME "TABRMD_TEST_BUS_NAME"
 
 typedef enum {
     UNKNOWN_TCTI,
@@ -64,9 +66,14 @@ typedef struct {
     char     *device_file;
     char     *socket_address;
     uint16_t  socket_port;
+    GBusType    tabrmd_bus_type;
+    const char *tabrmd_bus_name;
 } test_opts_t;
 
 /* functions to get test options from the user and to print helpful stuff */
+
+const char  *bus_name_from_type         (GBusType              bus_type);
+GBusType     bus_type_from_str          (const char*           bus_type_str);
 char* const  tcti_name_from_type        (TCTI_TYPE             tcti_type);
 TCTI_TYPE    tcti_type_from_name        (char const           *tcti_str);
 int          get_test_opts_from_env     (test_opts_t          *opts);


### PR DESCRIPTION
This patch series adds:
* code to allow the daemon to use a configurable (on the command line) name for the dbus connection
* a new initialization function to allow the TCTI to connect to a configurable bus type and name
* plumbing to allow the integration tests to take advantage of this configuration through the environment