### PR TITLE
Fix duplicate connection id detection

### DIFF
--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -309,7 +309,7 @@ gboolean
 connection_manager_contains_id (ConnectionManager *manager,
                                 const gchar       *id)
 {
-    return g_hash_table_contains (manager->connection_from_id_table, &id);
+    return g_hash_table_contains (manager->connection_from_id_table, id);
 }
 
 gboolean


### PR DESCRIPTION
According to https://developer.gnome.org/glib/stable/glib-Hash-Tables.html#g-hash-table-contains
g_hash_table_contains() takes a pointer, not a pointer to a pointer.