### PR TITLE
tcti-tabrmd: Replace use of glib type in _init_full with local enum.

### DIFF
--- a/src/include/tcti-tabrmd.h
+++ b/src/include/tcti-tabrmd.h
@@ -31,19 +31,23 @@
 extern "C" {
 #endif
 
-#include <gio/gio.h>
 #include <sapi/tpm20.h>
 #include <sapi/tss2_tcti.h>
 
 #define TCTI_TABRMD_DBUS_INTERFACE_DEFAULT "com.intel.tss2.TctiTabrmd"
 #define TCTI_TABRMD_DBUS_NAME_DEFAULT      "com.intel.tss2.Tabrmd"
-#define TCTI_TABRMD_DBUS_TYPE_DEFAULT      G_BUS_TYPE_SYSTEM
+#define TCTI_TABRMD_DBUS_TYPE_DEFAULT      TCTI_TABRMD_DBUS_TYPE_SYSTEM
+
+typedef enum {
+    TCTI_TABRMD_DBUS_TYPE_SESSION,
+    TCTI_TABRMD_DBUS_TYPE_SYSTEM,
+} TCTI_TABRMD_DBUS_TYPE;
 
 TSS2_RC tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT *context, size_t *size);
-TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT *context,
-                                    size_t            *size,
-                                    GBusType           bus,
-                                    const char        *name);
+TSS2_RC tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
+                                    size_t                 *size,
+                                    TCTI_TABRMD_DBUS_TYPE   bus,
+                                    const char             *name);
 
 #ifdef __cplusplus
 }

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -417,11 +417,12 @@ _out:
 }
 
 TSS2_RC
-tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT *context,
-                            size_t            *size,
-                            GBusType           bus_type,
-                            const char        *bus_name)
+tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
+                            size_t                 *size,
+                            TCTI_TABRMD_DBUS_TYPE   bus_type,
+                            const char             *bus_name)
 {
+    GBusType g_bus_type;
     GError *error = NULL;
     GVariant *fds_variant;
     guint64 id;
@@ -436,8 +437,17 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT *context,
         *size = sizeof (TSS2_TCTI_TABRMD_CONTEXT);
         return TSS2_RC_SUCCESS;
     }
-    if (bus_name == NULL ||
-        (bus_type != G_BUS_TYPE_SYSTEM && bus_type != G_BUS_TYPE_SESSION)) {
+    if (bus_name == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    switch (bus_type) {
+    case TCTI_TABRMD_DBUS_TYPE_SESSION:
+        g_bus_type = G_BUS_TYPE_SESSION;
+        break;
+    case TCTI_TABRMD_DBUS_TYPE_SYSTEM:
+        g_bus_type = G_BUS_TYPE_SYSTEM;
+        break;
+    default:
         return TSS2_TCTI_RC_BAD_VALUE;
     }
     /* Register dbus error mapping for tabrmd. Gets us RCs from Gerror codes */
@@ -445,7 +455,7 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT *context,
     init_tcti_data (context);
     TSS2_TCTI_TABRMD_PROXY (context) =
         tcti_tabrmd_proxy_new_for_bus_sync (
-            bus_type,
+            g_bus_type,
             G_DBUS_PROXY_FLAGS_NONE,
             bus_name,
             TABRMD_DBUS_PATH, /* object */
@@ -502,6 +512,6 @@ tss2_tcti_tabrmd_init (TSS2_TCTI_CONTEXT *context,
 {
     return tss2_tcti_tabrmd_init_full (context,
                                        size,
-                                       G_BUS_TYPE_SYSTEM,
-                                       TABRMD_DBUS_NAME_DEFAULT);
+                                       TCTI_TABRMD_DBUS_TYPE_DEFAULT,
+                                       TCTI_TABRMD_DBUS_NAME_DEFAULT);
 }

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -124,8 +124,8 @@ tcti_socket_init (char const *address,
  * Initialize a TCTI context for the tabrmd. Currently it requires no options.
  */
 TSS2_TCTI_CONTEXT*
-tcti_tabrmd_init (GBusType    bus_type,
-                  const char *bus_name)
+tcti_tabrmd_init (TCTI_TABRMD_DBUS_TYPE    bus_type,
+                  const char              *bus_name)
 {
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_ctx;

--- a/test/integration/tcti-connect-multiple.int.c
+++ b/test/integration/tcti-connect-multiple.int.c
@@ -50,7 +50,7 @@
 
 TSS2_RC
 tcti_tabrmd_init (TSS2_TCTI_CONTEXT **tcti_context,
-                  GBusType            bus_type,
+                  TCTI_TABRMD_DBUS_TYPE bus_type,
                   const char         *bus_name)
 {
     TSS2_RC rc;

--- a/test/integration/test-options.c
+++ b/test/integration/test-options.c
@@ -89,25 +89,25 @@ tcti_name_from_type (TCTI_TYPE tcti_type)
             return tcti_map_table[i].name;
     return NULL;
 }
-GBusType
+TCTI_TABRMD_DBUS_TYPE
 bus_type_from_str (const char *bus_type_str)
 {
     if (strcmp (bus_type_str, "system") == 0) {
-        return G_BUS_TYPE_SYSTEM;
+        return TCTI_TABRMD_DBUS_TYPE_SYSTEM;
     } else if (strcmp (bus_type_str, "session") == 0) {
-        return G_BUS_TYPE_SESSION;
+        return TCTI_TABRMD_DBUS_TYPE_SESSION;
     } else {
-        g_debug ("GBusType: default");
+        g_error ("Invalid bus type for %s", bus_type_str);
         return TCTI_TABRMD_DBUS_TYPE_DEFAULT;
     }
 }
 const char*
-bus_str_from_type (GBusType bus_type)
+bus_str_from_type (TCTI_TABRMD_DBUS_TYPE bus_type)
 {
     switch (bus_type) {
-    case G_BUS_TYPE_SESSION:
+    case TCTI_TABRMD_DBUS_TYPE_SESSION:
         return "session";
-    case G_BUS_TYPE_SYSTEM:
+    case TCTI_TABRMD_DBUS_TYPE_SYSTEM:
         return "system";
     default:
         return NULL;
@@ -140,8 +140,8 @@ sanity_check_test_opts (test_opts_t  *opts)
 #endif
     case TABRMD_TCTI:
         switch (opts->tabrmd_bus_type) {
-        case G_BUS_TYPE_SYSTEM:
-        case G_BUS_TYPE_SESSION:
+        case TCTI_TABRMD_DBUS_TYPE_SYSTEM:
+        case TCTI_TABRMD_DBUS_TYPE_SESSION:
             break;
         default:
             fprintf (stderr,

--- a/test/integration/test-options.h
+++ b/test/integration/test-options.h
@@ -29,6 +29,7 @@
 
 #include <gio/gio.h>
 #include "sapi/tpm20.h"
+#include "tcti-tabrmd.h"
 
 /* Default TCTI */
 #define TCTI_DEFAULT      TABRMD_TCTI
@@ -66,14 +67,14 @@ typedef struct {
     char     *device_file;
     char     *socket_address;
     uint16_t  socket_port;
-    GBusType    tabrmd_bus_type;
+    TCTI_TABRMD_DBUS_TYPE tabrmd_bus_type;
     const char *tabrmd_bus_name;
 } test_opts_t;
 
 /* functions to get test options from the user and to print helpful stuff */
 
-const char  *bus_name_from_type         (GBusType              bus_type);
-GBusType     bus_type_from_str          (const char*           bus_type_str);
+const char  *bus_name_from_type         (TCTI_TABRMD_DBUS_TYPE bus_type);
+TCTI_TABRMD_DBUS_TYPE bus_type_from_str (const char*           bus_type_str);
 char* const  tcti_name_from_type        (TCTI_TYPE             tcti_type);
 TCTI_TYPE    tcti_type_from_name        (char const           *tcti_str);
 int          get_test_opts_from_env     (test_opts_t          *opts);


### PR DESCRIPTION
Using GBusType directly seemed like the easiest thing to do at the time
but it causes a weird side effect for users: including the tcti-tabrmd.h
header requires that glib headers be on the include path. This is a bit
obnoxious.

This patch hides the GBusType by creating our own enum type to represent
the bus type.

This resolves #93.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>