### PR TITLE
tcti-tabrmd: Gracefully fail if D-Bus connection is not created

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -472,8 +472,9 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
         NULL,
         &error);
     if (call_ret == FALSE) {
-        g_error ("Failed to create connection with service: %s",
+        g_warning ("Failed to create connection with service: %s",
                  error->message);
+        return TSS2_TCTI_RC_NO_CONNECTION;
     }
     if (fd_list == NULL) {
         g_error ("call to CreateConnection returned a NULL GUnixFDList");


### PR DESCRIPTION
If creating a D-Bus connection fails, libtcti-tabrmd calls g_error() which
causes an abort() and the process to be terminated. This function should
not be used for expected errors, and failing to create a connection can
happen if for example the tpm2-abrmd.service was not started.

In this case, the program using the library could decide to fallback using
the device TCTI to access the TPM directly or just handle the error better
than being terminated due a SIGABRT signal.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>