### PR TITLE
logging: Use G_MESSAGES_DEBUG to enable debug & info logging for sysl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,5 @@ differentiate between the connections held by a single client.
 - Deconflict command line options: -t for TCTI selection, -a to fail if
 transient objects are already loaded in the TPM.
 - Clients can hold multiple TCTI connections again (fixed regression).
+- Syslog log handler now only shows info & debug messages when
+G_MESSAGES_DEBUG is set to 'all'.


### PR DESCRIPTION
…og handler.

This isn't "the right way" to do this but it's better than the current
state of affairs. This patch disables info and debug messages for the
syslog handler by default. If the G_MESSAGES_DEBUG environment variable
is set to "all" then info and log messages are enabled.

This resolves #30 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>