### PR TITLE
man: Fixup wording in the colophon & move common text to colophon.in

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,7 @@ EXTRA_DIST = \
     test/integration/test.h \
     test/integration/tpm2-struct-init.h \
     src/tcti-tabrmd.map \
+    man/colophon.in \
     man/tss2_tcti_tabrmd_init.3.in \
     man/tcti-tabrmd.7.in \
     man/tpm2-abrmd.8.in \
@@ -256,7 +257,7 @@ if TCTI_SOCKET
 else
 	echo ".nr HAVE_SOCKET_TCTI 0" >> $1
 endif
-	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g;" $2 >> $1
+	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g;" $2 $(srcdir)/man/colophon.in >> $1
 endef # man_tcti_prefix
 
 %-generated.c %-generated.h : src/tabrmd.xml

--- a/man/colophon.in
+++ b/man/colophon.in
@@ -1,0 +1,5 @@
+.SH COLOPHON
+This page is part of the @VERSION@ release of Intel's TPM2 Access Broker &
+Resource Management Daemon. A description of the project, information about
+reporting bugs, and the latest version of this page can be found at
+\%https://github.com/01org/tpm2\-abrmd/.

--- a/man/tcti-tabrmd.7.in
+++ b/man/tcti-tabrmd.7.in
@@ -16,8 +16,3 @@ for a detailed discussion of the TCTI API.
 Philip Tricca <philip.b.tricca@intel.com>
 .SH "SEE ALSO"
 .BR tpm2-abrmd (8)
-.SH COLOPHON
-This page is part of release @VERSION@ of Intel's implementation of the TCG
-TPM2 Software Stack (TSS2). A description of the project, information about
-reporting bugs, and the latest version of this page can be found at
-\%https://github.com/01org/tpm2\-abrmd/.

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -78,8 +78,3 @@ Disply version string.
 Philip Tricca <philip.b.tricca@intel.com>
 .SH "SEE ALSO"
 .BR tcsd (8)
-.SH COLOPHON
-This page is part of release @VERSION@ of Intel's implementation of the TCG
-TPM2 Software Stack (TSS2). A description of the project, information about
-reporting bugs, and the latest version of this page can be found at
-\%https://github.com/01org/tpm2\-abrmd/.

--- a/man/tss2_tcti_tabrmd_init.3.in
+++ b/man/tss2_tcti_tabrmd_init.3.in
@@ -143,8 +143,3 @@ Philip Tricca <philip.b.tricca@intel.com>
 .SH "SEE ALSO"
 .BR tcti-tabrmd (7),
 .BR tpm2-abrmd (8)
-.SH COLOPHON
-This page is part of release @VERSION@ of Intel's implementation of the TCG
-TPM2 Software Stack (TSS2). A description of the project, information about
-reporting bugs, and the latest version of this page can be found at
-\%https://github.com/01org/tpm2\-abrmd/.


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>