### PR TITLE
build: Add documentation and license file to EXTRA_DIST.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,7 +110,12 @@ EXTRA_DIST = \
     dist/tcti-tabrmd.pc.in \
     dist/tpm2-abrmd.service \
     dist/tpm-udev.rules \
-    scripts/int-log-compiler.sh
+    scripts/int-log-compiler.sh \
+    CHANGELOG.md \
+    CONTRIBUTING.md \
+    INSTALL.md \
+    LICENSE \
+    README.md
 
 CLEANFILES = \
     $(man3_MANS) \


### PR DESCRIPTION
This causes these files to be included in release tarballs created by
`make dist`.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>