### PR TITLE
CommandSource: Remove 'else if' expression from range check.

### DIFF
--- a/src/command-source.c
+++ b/src/command-source.c
@@ -303,7 +303,7 @@ process_client_fd (CommandSource      *source,
         } else {
             goto fail_out;
         }
-    } else if (command_size < TPM_HEADER_SIZE || command_size > UTIL_BUF_MAX) {
+    } else {
         goto fail_out;
     }
     attributes = command_attrs_from_cc (source->command_attrs,


### PR DESCRIPTION
This is redundant since it's the negation of the initial if.
Conditionals like this are also a bad idea since the code is structured
such that the if or the else must be taken.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>