### PR TITLE
build: Remove default value for simulator config.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,15 +100,20 @@ AC_SUBST([udevrulesdir], [$with_udevrulesdir])
 #
 # simulator binary
 #
+AC_MSG_CHECKING([for simulator binary: $with_simulatorbin])
 AC_ARG_WITH([simulatorbin],
             [AS_HELP_STRING([--with-simulatorbin=tpm_server],[simulator executable])],
-            [],
-            [with_simulatorbin=../ibmtpm532/src/tpm_server])
-AX_NORMALIZE_PATH([with_simulatorbin])
-AS_IF([test -f "$with_simulatorbin"],
-      [AC_SUBST([SIMULATOR_BIN],[$with_simulatorbin])],
-      [AC_MSG_WARN([TPM simulator binary does not exist integration tests will not be run])])
-AM_CONDITIONAL([SIMULATOR_BIN],[test -f "$with_simulatorbin"])
+            [AS_IF([test \( -f "$with_simulatorbin" \) -a \( -x "$with_simulatorbin" \)],
+                   [AC_MSG_RESULT([yes])
+                    AC_SUBST([SIMULATOR_BIN],[$with_simulatorbin])
+                    AX_NORMALIZE_PATH([with_simulatorbin])
+                    with_simulatorbin_set=yes],
+                   [AC_MSG_RESULT([no])
+                    AC_MSG_ERROR([Simulator binary provided does not exist or not executable. Check path: $with_simulatorbin])])],
+            [AC_MSG_RESULT([no])
+             AC_MSG_WARN([No simulator binary provided. Integration tests disabled.])
+             with_simulatorbin_set=no])
+AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
 
 # preprocessor / compiler / linker flags
 #   these macros are defined in m4/flags.m4


### PR DESCRIPTION
The previous implementation used a default if none was provided by the
caller. If this default (or one provided) doesn't exist then a warning
was printed and the integration tests disabled. This silent disabling of
the tests as the result of what may have been a typo isn't the best
approach.

The new approach is to provide no default. If the caller doesn't provde
a path to a simulator then the integration tests are disabled. If they
do provide a path and it doesn't exist then the configuration is halted
with an error.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>