### PR TITLE
CommandSource: Allow command buffers with no parameters.

### DIFF
--- a/src/command-source.c
+++ b/src/command-source.c
@@ -303,6 +303,8 @@ process_client_fd (CommandSource      *source,
         } else {
             goto fail_out;
         }
+    } else if (command_size == TPM_HEADER_SIZE) {
+        /* No more data. Command has no parameters / handles / auths etc. */
     } else {
         goto fail_out;
     }


### PR DESCRIPTION
The logic previously would reject command buffers with size less than or
equal to 10 bytes (the size of a command / response header). It turns
out that there are valid commands with no parameters (just headers) like
TPM2_GetTestResult.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>