### PR TITLE
build: Clonse 1.x branch of TSS for travis CI.

### DIFF
--- a/.ci/ci-tss-install.sh
+++ b/.ci/ci-tss-install.sh
@@ -32,7 +32,38 @@
 # runs 'make install'
 # see: https://github.com/travis-ci/travis-ci/issues/3088
 
+usage_error ()
+{
+    echo "$0: $*" >&2
+    print_usage >&2
+    exit 2
+}
+
+print_usage ()
+{
+    cat <<END
+Usage:
+    $0 --tss-srcdir=DIR
+END
+}
+TSS_SRCDIR=""
+while test $# -gt 0; do
+    case $1 in
+    --help) print_usage; exit $?;;
+    -d|--tss-srcdir) TSS_SRCDIR=$2; shift;;
+    -d=*|--tss-srcdir=*) TSS_SRCDIR="${1#*=}";;
+    --) shift; break;;
+    -*) usage_error "invalid option: '$1'";;
+    *) break;
+    esac
+    shift
+done
+
+if [ ! -d "${TSS_SRCDIR}" ]; then
+    usage_error "missing option: --tss-srcdir is required"
+fi
+
 PATH=${PATH}:/usr/local/clang/bin
-(pushd ${TRAVIS_BUILD_DIR}/TPM2.0-TSS && \
+(pushd ${TSS_SRCDIR} && \
  make install && \
  popd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,12 @@ env:
     - coverity_scan_run_condition='"$CC" = gcc'
 
 install:
-  - git clone https://github.com/01org/TPM2.0-TSS.git
-  - pushd TPM2.0-TSS
+  - git clone -b 1.x --single-branch https://github.com/01org/tpm2-tss.git
+  - pushd tpm2-tss
   - ./bootstrap
   - ./configure
   - make -j$(nproc)
-  - sudo ../.ci/ci-tss-install.sh
+  - sudo ../.ci/ci-tss-install.sh --tss-srcdir="${TRAVIS_BUILD_DIR}"/tpm2-tss
   - popd && sudo ldconfig /usr/local/lib
   - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
   - sha256sum ibmtpm532.tar | grep -q ^abc0b420257917ccb42a9750588565d5e84a2b4e99a6f9f46c3dad1f9912864f


### PR DESCRIPTION
The master branch of the TSS is undergoing updates that break backward
compatability with the 1.x releases. Eventually it will become a 2.0
version. Since we're a consumer of the TSS we need a stable API and
that's 1.x till 2.x is released.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>