### PR TITLE
AccessBroker: fix build warning in access_broker_send_command() function

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -430,7 +430,7 @@ access_broker_send_command (AccessBroker  *broker,
 {
     Tpm2Response   *response = NULL;
     Connection     *connection = NULL;
-    guint8         *buffer;
+    guint8         *buffer = NULL;
     size_t          buffer_size = 0;
 
     g_debug ("access_broker_send_command: AccessBroker: 0x%" PRIxPTR


### PR DESCRIPTION
GCC7 complains that the buffer variable may be used uninitialized, which
causes a build error:

src/access-broker.c: In function ‘access_broker_send_command’:
src/access-broker.c:446:13: error: ‘buffer’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             free (buffer);
             ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:2143: src/access-broker.lo] Error 1
make[1]: *** Waiting for unfinished jobs....

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>