### PR TITLE
build against tss master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
   - cmake ../ -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Release
   - make -j$(nproc) install
   - popd
-  - git clone -b 1.x --single-branch https://github.com/01org/tpm2-tss.git
+  - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
   - ./bootstrap
   - ./configure --prefix=${PREFIX}

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -631,13 +631,13 @@ tpm2_command_get_auth_attrs (Tpm2Command *command,
     size_t attrs_end;
 
     if (command == NULL) {
-        return (TPMA_SESSION)(UINT32)0;
+        return (TPMA_SESSION)(UINT8)0;
     }
     attrs_end = AUTH_SESSION_ATTRS_END_OFFSET (command, auth_offset);
     if (attrs_end > command->buffer_size) {
         g_warning ("%s attempt to access session attributes overruns command "
                    "buffer", __func__);
-        return (TPMA_SESSION)(UINT32)0;
+        return (TPMA_SESSION)(UINT8)0;
     }
     return AUTH_GET_SESSION_ATTRS (command, auth_offset);
 }

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -104,7 +104,7 @@
 #define AUTH_SESSION_ATTRS_END_OFFSET(cmd, index) \
     (AUTH_SESSION_ATTRS_OFFSET (cmd, index) + sizeof (UINT8))
 #define AUTH_GET_SESSION_ATTRS(cmd, index) \
-    ((TPMA_SESSION)(UINT32)cmd->buffer [AUTH_SESSION_ATTRS_OFFSET (cmd, index)])
+    ((TPMA_SESSION)(UINT8)cmd->buffer [AUTH_SESSION_ATTRS_OFFSET (cmd, index)])
 /* authorization */
 #define AUTH_AUTH_SIZE_OFFSET(cmd, index) \
     (AUTH_SESSION_ATTRS_END_OFFSET (cmd, index))


### PR DESCRIPTION
src/access-broker.c:446:13: error: ‘buffer’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             free (buffer);

Signed-off-by: William Roberts <william.c.roberts@intel.com>