### PR TITLE
CommandSource: Set BUF_MAX to PIPE_BUF.

### DIFF
--- a/src/command-source.h
+++ b/src/command-source.h
@@ -39,12 +39,10 @@
 
 G_BEGIN_DECLS
 
-/* Chunk size for allocations to hold data from clients. */
-#define BUF_SIZE 4096
 /* Maximum buffer size for client data. Connections that send a single
  * command larger than this size will be closed.
  */
-#define BUF_MAX  4*BUF_SIZE
+#define BUF_MAX  PIPE_BUF
 
 typedef struct _CommandSourceClass {
     ThreadClass       parent;


### PR DESCRIPTION
The ResponseSink object currently assumes that all write operations are
atomic. Since we use pipes as the underlying mechanism for sending
responses back to clients we can't assume that writes over PIPE_BUF will
be atomic. This commit is a work around that reduces the maximum buffer
size to PIPE_BUF to guarantee that our write operations will be atomic.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>