### PR TITLE
Refuse running the daemon as root by default

### DIFF
--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -746,6 +746,9 @@ parse_opts (gint            argc,
           options->prng_seed_file },
         { "version", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
           show_version, "Show version string" },
+        { "allow-root", 0, 0, G_OPTION_ARG_NONE,
+          &options->allow_root,
+          "Allow the daemon to run as root, which is not recommended" },
         { NULL },
     };
 
@@ -807,6 +810,11 @@ main (int argc, char *argv[])
     gmain_data.options.tcti_options = tcti_options_new ();
     parse_opts (argc, argv, &gmain_data.options);
     gmain_data.tcti = tcti_options_get_tcti (gmain_data.options.tcti_options);
+
+    if (geteuid() == 0 && ! gmain_data.options.allow_root) {
+        g_print ("refusing to run as root. pass --allow-root if you know what you're doing.");
+        return 1;
+    }
 
     g_mutex_init (&gmain_data.init_mutex);
     gmain_data.loop = g_main_loop_new (NULL, FALSE);

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -623,7 +623,7 @@ init_thread_func (gpointer user_data)
                  "access broker 0x%" PRIxPTR " RC: 0x%" PRIx32,
                  (uintptr_t)data->access_broker,
                  rc);
-    if ((loaded_trans_objs > 0) & data->options.fail_on_loaded_trans) {
+    if ((loaded_trans_objs > 0) && data->options.fail_on_loaded_trans) {
         tabrmd_critical ("TPM reports 0x%" PRIx32 " loaded transient objects, "
                          "aborting", loaded_trans_objs);
     }

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -64,6 +64,7 @@ typedef struct tabrmd_options {
     guint           max_transient_objects;
     gchar          *dbus_name;
     const gchar    *prng_seed_file;
+    gboolean        allow_root;
 } tabrmd_options_t;
 
 GQuark  tabrmd_error_quark (void);


### PR DESCRIPTION
A little suggestion, refusing to run as root by default. Maybe doing this via the default D-Bus service configuration is cleaner. On the other hand this approach is more explicit and noticeable.

Also one minor bugfix is included I stumbled upon.