### PR TITLE
Avoid looping over unused FDs in `select()`

### DIFF
--- a/src/command-source.h
+++ b/src/command-source.h
@@ -56,6 +56,7 @@ typedef struct _CommandSource {
     gint               wakeup_send_fd;
     fd_set             receive_fdset;
     Sink              *sink;
+    int                maxfd;
 } CommandSource;
 
 #define TYPE_COMMAND_SOURCE              (command_source_get_type   ())


### PR DESCRIPTION
A suggestion for performance improvement.