### PR TITLE
build: Replace use of git in configure.ac with static version string.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,27 @@
 # Release Process:
 This document describes the general process that maintainers must follow when making a release of the `tabrmd`.
 
-# Versioning Scheme
+# Version Numbers
 Our releases will follow the semantic versioning scheme.
-You can find a thorough description of this scheme here: semantic versioning.
+You can find a thorough description of this scheme here: [http://semver.org/](http://semver.org/)
 In short, this scheme has 3 parts to the version number: A.B.C
 
 * A is the 'major' version, incremented when an API incompatible change is made
 * B is the 'minor' version, incremented when an API compatible change is made
 * C is the 'micro' version, incremented for bug fix releases
-Please refer to the Semantic Versioning website for the authoritative description.
+Please refer to the [Semantic Versioning](http://semver.org/) website for the authoritative description.
+
+## Version String
+The version string is set for the rest of the autotools bits by autoconf.
+Autoconf gets this string from the `AC_INIT` macro in the configure.ac file.
+Once you decide on the next version number (using the scheme above) you must set it manually in configure.ac.
+The version string must be in the form `A.B.C` where `A`, `B` and `C` are integers representing the major, minor and micro components of the version number.
+
+## Release Candidates
+In the run up to a release the maintainers may create tags to identify progress toward the release.
+In these cases we will append a string to the release number to indicate progress using the abbreviation `rc` for 'release candidate'.
+This string will take the form of `_rcX`.
+We append an incremental digit `X` in case more than one release candidate is necessary to communicate progress as development moves forward.
 
 # Static Analysis
 Before a release is made the `coverity_scan` branch must be updated to the point in git history where the release will be made from.
@@ -17,23 +29,14 @@ This branch must be pushed to github which will cause the travis-ci infrastructu
 The results of this scan must be dispositioned by the maintainers before the release is made.
 
 # Git Tags
-When a release is made a tag is created in the git repo identifying the release by version number e.g. A.B.C where A, B and C are integers representing the major, minor and micro components of the version number.
-The tabrmd build system uses these tags to generate the version string used in the generation of the release tarball and so the tag must be created as the first step in the release process.
-After the tag has been created the `distclean` make target should be executed, followed by the `bootstrap` script to regenerate the `configure` script.
+When a release is made a tag is created in the git repo identifying the release by the [version string](#Version String).
 The tag should be pushed to upstream git repo as the last step in the release process.
-**NOTE** that tags of this form should be considered immutable:
-If you are maintaining a build system / product that uses a specific version of this software you can rely on these tags to remain unchanged.
+**NOTE** tags for release candidates will be deleted from the git repository after a release with the corresponding version number has been made.
+**NOTE** release (not release candidate) tags should be considered immutable.
 
 ## Signed tags
 Git supports GPG signed tags and for releases after the `1.1.0` release will have tags signed by a maintainer.
 For details on how to sign and verify git tags see: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work.
-
-## Release Candidates
-In the run up to a release the maintainers may create tags to identify progress toward the release.
-In these cases we will append a string to the release number to indicate progress using the abbreviation `rc` for 'release candidate'.
-This string will take the form of '_rcX'.
-We append an incremental digit 'X' in case more than one tag is necessary to communicate progress as development moves forward.
-**NOTE** that tags of this form will be removed after a release with the corresponding version number has been made.
 
 # Release tarballs
 We use the git tag as a way to mark the point of the release in the projects history.
@@ -44,18 +47,20 @@ To make a release tarball use the `distcheck` make target.
 This target incldues a number of sanity checks that are extremely helpful.
 For more information on `automake` and release tarballs see: https://www.gnu.org/software/automake/manual/html_node/Dist.html#Dist
 
-Release tarballs may be created for release candidates but this is not currently a requirement of this process.
-
 ## Hosting Releases on Github
 Github automagically generates a page in their UI that maps git tags to 'releases' (even if the tag isn't for a release).
 Additionally they support hosting release tarballs through this same interface.
 The release tarball created in the previous step must be posted to github using the release interface.
 Additionally this tarball must be accompanied by a detached GPG signature.
 The Debian wiki has an excellent description of how to post a signed release to Github here: https://wiki.debian.org/Creating%20signed%20GitHub%20releases
+**NOTE** release candidates must be taken down after a release with the corresponding version number is available.
 
 # Signing Keys
 The GPG keys used to sign a release tag and the associated tarball must be the same.
-Additionally they must belong to a project maintainer and must be discoverable using a public GPG key server.
+Additionally they must:
+* belong to a project maintainer
+* be discoverable using a public GPG key server
+* be associated with the maintainers github account (https://help.github.com/articles/adding-a-new-gpg-key-to-your-github-account/)
 
 # Announcements
 Release candidates and proper releases should be announced on the 01.org TPM2 mailing list: https://lists.01.org/mailman/listinfo/tpm2.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,8 @@
 AC_INIT([tpm2-abrmd],
-        [m4_esyscmd_s([git describe --tags --always --dirty])])
+        [1.1.1_rc1],
+        [https://github.com/01org/tpm2-abrmd/issues],
+        [],
+        [https://github.com/01org/tpm2-abrmd])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_LN_S


### PR DESCRIPTION
This makes our source releases usable for those who wish to recreate the
configure script. Of course we don't advise that people do this, though
we shouldn't do anything to actively prevent someone from doing so.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>