### PR TITLE
build: Add configure option to prepend string to udev rules file.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,12 +116,13 @@ systemd unit in the right location with the following configure option:
 --with-systedsystemunitdir=/lib/systemd/system
 ```
 
-### udev Rules: `--with-udevrulesdir`
+### udev Rules
 The typical operation for the `tpm2-abrmd` is for it to communicate directly
 with the Linux TPM driver using `libtcti-device` from the TPM2.0-TSS project.
 This requires that the user account that's running the `tpm2-abrmd` have both
 read and write access to the TPM device node `/dev/tpm[0-9]`.
 
+#### `--with-udevrulesdir`
 This requires that `udev` be instructed to set the owner and group for this
 device node when its created. We provide such a udev rule that is installed to
 `${libdir}/udev/rules.d`. If your distro stores these rules elsewhere you will
@@ -132,6 +133,12 @@ rules in the right location with the following configure option:
 ```
 --with-udevrulesdir=/etc/udev/rules.d
 ```
+
+#### `--with-udevrulesprefix`
+It is common for Linux distros to prefix udev rules files with a numeric
+string (e.g. "70-"). This allows for the rules to be applied in a predictable
+order. This option allows for the name of the installed udev rules file to
+have a string prepended to the file name when it is installed.
 
 ### Enable Unit Tests: `--enable-unit`
 When provided to the `./configure` script this option will attempt to detect

--- a/Makefile.am
+++ b/Makefile.am
@@ -95,6 +95,9 @@ man8_MANS = man/man8/tpm2-abrmd.8
 install-data-hook:
 	$(LN_S) -f tss2_tcti_tabrmd_init.3 \
                 $(DESTDIR)$(mandir)/man3/tss2_tcti_tabrmd_init_full.3
+if WITH_UDEVRULESPREFIX
+	mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
+endif
 
 libtcti_tabrmddir      = $(includedir)/tcti
 libtcti_tabrmd_HEADERS = $(srcdir)/src/include/tcti-tabrmd.h

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,10 @@ AC_ARG_WITH([udevrulesdir],
             [with_udevrulesdir=${libdir}/udev/rules.d])
 AX_NORMALIZE_PATH([with_udevrulesdir])
 AC_SUBST([udevrulesdir], [$with_udevrulesdir])
+AC_ARG_WITH([udevrulesprefix],
+            [AS_HELP_STRING([--with-udevrulesprefix=XY],[prefix for udev rules file])],
+            [AC_SUBST([udevrulesprefix],[$with_udevrulesprefix])])
+AM_CONDITIONAL(WITH_UDEVRULESPREFIX, [test -n "$with_udevrulesprefix"])
 #
 # simulator binary
 #


### PR DESCRIPTION
This is intended to make life for distro packagers easier. Just provide
the configure script with --with-udevrulesprefix="XY-" and the installed
udev rules file name will have the string "XY-" prepended to it.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>