### PR TITLE
build: Add options to the configure script for the systemd preset file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ test/tcti-tabrmd_read-write
 test/integration/*
 !test/integration/*.c
 !test/integration/*.h
+dist/*.preset
 dist/*.service

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -103,18 +103,33 @@ following configure option:
 --with-dbuspolicydir=/etc/dbus-1/system.d
 ```
 
-### Systemd Uint: `--with-systedsystemunitdir`
+### Systemd
 In most configurations the `tpm2-abrmd` daemon should be started as part of
-the boot process. To enable this we provide a systemd unit. By default the
-build installs this file to `${libdir}/systemd/system`. Just like D-Bus
-the location of unit files is distro specific and so you may need to
-configure the build to install this file in the appropriate location.
+the boot process. To enable this we provide a systemd unit as well as a
+systemd preset file.
+
+#### Systemd Uint: `--with-systedsystemunitdir`
+By default the build installs this file to `${libdir}/systemd/system. Just
+like D-Bus the location of unit files is distro specific and so you may need
+to configure the build to install this file in the appropriate location.
 
 Again using Debian as an example we can instruct the build to install the
 systemd unit in the right location with the following configure option:
 ```
 --with-systedsystemunitdir=/lib/systemd/system
 ```
+
+#### Systemd Preset Dir: `--with-systemdpresetdir=DIR`
+By default the build installs the systemd preset file for the tabrmd to
+`${libdir}/systemd/system-preset`. If you need to install this file to a
+different directory pass the desired path to the `configure` script using this
+option.
+
+#### Systemd Preset Default: `--with-systemdpresetdisable`
+The systemd preset file will enable the tabrmd by default, causing it to be
+started by systemd on boot. If you wish for the daemon to be disabled by
+default some reason you may use this option to the `configure` script to do
+so.
 
 ### udev Rules
 The typical operation for the `tpm2-abrmd` is for it to communicate directly

--- a/Makefile.am
+++ b/Makefile.am
@@ -113,6 +113,7 @@ EXTRA_DIST = \
     man/tpm2-abrmd.8.in \
     dist/tpm2-abrmd.conf \
     dist/tcti-tabrmd.pc.in \
+    dist/tpm2-abrmd.preset \
     dist/tpm2-abrmd.service \
     dist/tpm-udev.rules \
     scripts/int-log-compiler.sh \
@@ -142,7 +143,7 @@ udevrules_DATA   = dist/tpm-udev.rules
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = dist/tpm2-abrmd.service
 endif # HAVE_SYSTEMD
-
+systemdpreset_DATA = dist/tpm2-abrmd.preset
 
 @VALGRIND_CHECK_RULES@
 VALGRIND_G_DEBUG = fatal-criticals,gc-friendly
@@ -274,6 +275,10 @@ endef # man_tcti_prefix
 	$(call make_parent_dir,$@)
 	$(GDBUS_CODEGEN) --interface-prefix=com.intel.tss2. \
 	    --generate-c-code=src/tabrmd-generated $^
+
+%.preset : %.preset.in
+	$(call make_parent_dir,$@)
+	sed -e "s,[@]SYSTEMD_PRESET_DEFAULT[@],$(SYSTEMD_PRESET_DEFAULT),g;" $^ > $@
 
 %.service : %.service.in
 	$(call make_parent_dir,$@)

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,21 @@ AS_IF([test "x$with_systemdsystemunitdir" != xno],
       [$with_systemdsystemunitdir])])
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
 
+# systemd preset directory
+AC_ARG_WITH([systemdpresetdir],
+            AS_HELP_STRING([--with-systemdpresetdir=DIR],
+                           [Directory for systemd preset files]),
+            [],
+            [with_systemdpresetdir=${libdir}/systemd/system-preset])
+AC_SUBST([systemdpresetdir], [$with_systemdpresetdir])
+
+# systemd preset default (enable / disable)
+AC_ARG_WITH([systemdpresetdisable],
+             AS_HELP_STRING([--with-systemdpresetdisable],
+                            [Configure systemd preset to 'disable', default is 'enable']),
+            [AC_SUBST([SYSTEMD_PRESET_DEFAULT],[disable])],
+            [AC_SUBST([SYSTEMD_PRESET_DEFAULT],[enable])])
+
 #
 # dbus
 #

--- a/dist/tpm2-abrmd.preset.in
+++ b/dist/tpm2-abrmd.preset.in
@@ -1,0 +1,1 @@
+@SYSTEMD_PRESET_DEFAULT@ tpm2-abrmd.service


### PR DESCRIPTION
This allows the caller to specify the default install path for the
preset file, as well as the enable / disable state for the service unit.
By default the install path is `${libdir}/systemd/service-preset`. This
can be overriden using the --with-systemdpresetdir=DIR option. By
default the tpm2-abrmd preset will enable the daemon. It may be disabled
by default using the `--with-systemdpresetdisable` option.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>