### PR TITLE
build: Check for compatible SAPI version @ configure time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
 
+## Unreleased
+### Added
+- Check SAPI library is < 2.0.0 (API change upstream).
+
 ## 1.1.1 - 2017-08-25
 ### Added
 - Systemd 'preset' file and corresponding options to the configure script.

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ PKG_CHECK_MODULES([DBUS], [dbus-1])
 PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
-PKG_CHECK_MODULES([SAPI],[sapi])
+PKG_CHECK_MODULES([SAPI],[sapi < 2.0.0])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
 AC_PATH_PROG([GDBUS_CODEGEN], [`$PKG_CONFIG --variable=gdbus_codegen gio-2.0`])
 if test -z "$GDBUS_CODEGEN"; then


### PR DESCRIPTION
The upstream TSS master branch now has API / ABI incompatible changes
with the 1.x stable releases. The tabrmd releases are maintaining
compatibility with the 1.x TSS until a 2.x release is made.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>