### PR TITLE
travis-ci: Upgrade from 1.0.1 to 1.1.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ env:
 
 install:
   - mkdir ${DESTDIR}
-  - wget https://cmocka.org/files/1.0/cmocka-1.0.1.tar.xz
-  - tar -Jxvf cmocka-1.0.1.tar.xz
-  - mkdir cmocka-1.0.1/build && pushd cmocka-1.0.1/build
+  - wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
+  - tar -Jxvf cmocka-1.1.1.tar.xz
+  - mkdir cmocka-1.1.1/build && pushd cmocka-1.1.1/build
   - cmake ../ -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Release
   - make -j$(nproc) install
   - popd


### PR DESCRIPTION
Travis-ci upduated their images recently and the new version of clang
(updated from 3.8.4 to 3.9.something) complains about some of the cmocka
initialization stuff. This was fixed between 1.0.1 and 1.1.1.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>