### PR TITLE
tcti-tabrmd: Use local sockets instead of pipes.

### DIFF
--- a/src/command-source.c
+++ b/src/command-source.c
@@ -173,7 +173,7 @@ command_source_on_new_connection (ConnectionManager   *connection_manager,
                                   CommandSource       *command_source)
 {
     ssize_t ret;
-    int new_fd = connection_receive_fd (connection);
+    int new_fd = connection_fd (connection);
 
     g_info ("command_source_on_new_connection: adding new client fd: %d",
             new_fd);

--- a/src/command-source.h
+++ b/src/command-source.h
@@ -30,7 +30,6 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <pthread.h>
-#include <sys/select.h>
 
 #include "command-attrs.h"
 #include "connection-manager.h"
@@ -42,7 +41,7 @@ G_BEGIN_DECLS
 /* Maximum buffer size for client data. Connections that send a single
  * command larger than this size will be closed.
  */
-#define BUF_MAX  PIPE_BUF
+#define BUF_MAX 4096
 
 typedef struct _CommandSourceClass {
     ThreadClass       parent;

--- a/src/connection.h
+++ b/src/connection.h
@@ -40,8 +40,7 @@ typedef struct _ConnectionClass {
 
 typedef struct _Connection {
     GObject             parent_instance;
-    gint                receive_fd;
-    gint                send_fd;
+    gint                fd;
     guint64             id;
     HandleMap          *transient_handle_map;
 } Connection;
@@ -54,8 +53,7 @@ typedef struct _Connection {
 #define CONNECTION_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj),  TYPE_CONNECTION, ConnectionClass))
 
 GType            connection_get_type     (void);
-Connection*      connection_new          (gint            *receive_fd,
-                                          gint            *send_fd,
+Connection*      connection_new          (gint            *client_fd,
                                           guint64          id,
                                           HandleMap       *transient_handle_map);
 gboolean         connection_equal_fd     (gconstpointer    a,
@@ -64,15 +62,11 @@ gboolean         connection_equal_id     (gconstpointer    a,
                                           gconstpointer    b);
 gpointer         connection_key_fd       (Connection      *session);
 gpointer         connection_key_id       (Connection      *session);
-gint             connection_receive_fd   (Connection      *session);
-gint             connection_send_fd      (Connection      *session);
+gint             connection_fd           (Connection      *session);
 HandleMap*       connection_get_trans_map(Connection      *session);
 /* not part of the public API but included here for testing */
-int              create_pipe_pair  (int *recv,
-                                    int *send,
-                                    int flags);
-int              create_pipe_pairs (int pipe_fds_a[],
-                                    int pipe_fds_b[],
-                                    int flags);
+int              create_fd_pair (int *client_fd,
+                                 int *server_fd,
+                                 int  flags);
 
 #endif /* CONNECTION_H */

--- a/src/response-sink.c
+++ b/src/response-sink.c
@@ -207,7 +207,7 @@ response_sink_process_response (Tpm2Response *response)
     guint32      size    = tpm2_response_get_size (response);
     guint8      *buffer  = tpm2_response_get_buffer (response);
     Connection  *connection = tpm2_response_get_connection (response);
-    gint         fd      = connection_send_fd (connection);
+    gint         fd      = connection_fd (connection);
 
     g_debug ("response_sink_thread got response: 0x%" PRIxPTR " size %d",
              (uintptr_t)response, size);

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -254,7 +254,7 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
     gmain_data_t *data = (gmain_data_t*)user_data;
     HandleMap   *handle_map = NULL;
     Connection *connection = NULL;
-    gint client_fds[2] = { 0, 0 }, ret = 0;
+    gint client_fd = 0, ret = 0;
     GVariant *response_variants[2], *response_tuple;
     GUnixFDList *fd_list = NULL;
     guint64 id = 0, id_pid_mix = 0;
@@ -292,14 +292,14 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
     handle_map = handle_map_new (TPM_HT_TRANSIENT, data->options.max_transient_objects);
     if (handle_map == NULL)
         g_error ("Failed to allocate new HandleMap");
-    connection = connection_new (&client_fds[0], &client_fds[1], id_pid_mix, handle_map);
+    connection = connection_new (&client_fd, id_pid_mix, handle_map);
     g_object_unref (handle_map);
     if (connection == NULL)
         g_error ("Failed to allocate new connection.");
-    g_debug ("Created connection with fds: %d, %d and id: 0x%" PRIx64,
-             client_fds[0], client_fds[1], id_pid_mix);
+    g_debug ("Created connection with fd: %d and id: 0x%" PRIx64,
+             client_fd, id_pid_mix);
     /* prepare tuple variant for response message */
-    fd_list = g_unix_fd_list_new_from_array (client_fds, 2);
+    fd_list = g_unix_fd_list_new_from_array (&client_fd, 1);
     response_variants[0] = handle_array_variant_from_fdlist (fd_list);
     /* return the random id to client, *not* xor'd with PID */
     response_variants[1] = g_variant_new_uint64 (id);

--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -40,12 +40,8 @@
 
 #define TSS2_TCTI_TABRMD_ID(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->id
-#define TSS2_TCTI_TABRMD_FDS(context) \
-    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->pipe_fds
-#define TSS2_TCTI_TABRMD_FD_RECEIVE(context) \
-    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->fd_receive
-#define TSS2_TCTI_TABRMD_FD_TRANSMIT(context) \
-    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->fd_transmit
+#define TSS2_TCTI_TABRMD_FD(context) \
+    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->fd
 #define TSS2_TCTI_TABRMD_PROXY(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->proxy
 #define TSS2_TCTI_TABRMD_HEADER(context) \
@@ -94,8 +90,7 @@ typedef enum {
 typedef struct {
     TSS2_TCTI_CONTEXT_COMMON_V1    common;
     guint64                        id;
-    int                            fd_receive;
-    int                            fd_transmit;
+    int                            fd;
     TctiTabrmd                    *proxy;
     tpm_header_t                   header;
     tcti_tabrmd_state_t            state;

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -64,8 +64,8 @@ tss2_tcti_tabrmd_transmit (TSS2_TCTI_CONTEXT *context,
         return TSS2_TCTI_RC_BAD_SEQUENCE;
     }
     g_debug_bytes (command, size, 16, 4);
-    g_debug ("blocking on FD_TRANSMIT: %d", TSS2_TCTI_TABRMD_FD_TRANSMIT (context));
-    write_ret = write_all (TSS2_TCTI_TABRMD_FD_TRANSMIT (context),
+    g_debug ("blocking on FD_TRANSMIT: %d", TSS2_TCTI_TABRMD_FD (context));
+    write_ret = write_all (TSS2_TCTI_TABRMD_FD (context),
                            command,
                            size);
     /* should switch on possible errors to translate to TSS2 error codes */
@@ -201,7 +201,7 @@ tss2_tcti_tabrmd_receive (TSS2_TCTI_CONTEXT *context,
     if (response != NULL && *size < TPM_HEADER_SIZE) {
         return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
     }
-    ret = tcti_tabrmd_poll (tabrmd_ctx->fd_receive, timeout);
+    ret = tcti_tabrmd_poll (TSS2_TCTI_TABRMD_FD (context), timeout);
     switch (ret) {
     case -1:
         return TSS2_TCTI_RC_TRY_AGAIN;
@@ -212,7 +212,7 @@ tss2_tcti_tabrmd_receive (TSS2_TCTI_CONTEXT *context,
     }
     /* make sure we've got the response header */
     if (tabrmd_ctx->index < TPM_HEADER_SIZE) {
-        ret = read_data (tabrmd_ctx->fd_receive,
+        ret = read_data (TSS2_TCTI_TABRMD_FD (tabrmd_ctx),
                          &tabrmd_ctx->index,
                          tabrmd_ctx->header_buf,
                          TPM_HEADER_SIZE - tabrmd_ctx->index);
@@ -245,7 +245,7 @@ tss2_tcti_tabrmd_receive (TSS2_TCTI_CONTEXT *context,
     if (*size < tabrmd_ctx->header.size) {
         return TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
     }
-    ret = read_data (tabrmd_ctx->fd_receive,
+    ret = read_data (TSS2_TCTI_TABRMD_FD (tabrmd_ctx),
                      &tabrmd_ctx->index,
                      response,
                      tabrmd_ctx->header.size - tabrmd_ctx->index);
@@ -268,19 +268,12 @@ tss2_tcti_tabrmd_finalize (TSS2_TCTI_CONTEXT *context)
         g_warning ("Invalid parameter");
         return;
     }
-    if (TSS2_TCTI_TABRMD_FD_RECEIVE (context) != 0) {
-        ret = close (TSS2_TCTI_TABRMD_FD_RECEIVE (context));
-        TSS2_TCTI_TABRMD_FD_RECEIVE (context) = 0;
+    if (TSS2_TCTI_TABRMD_FD (context) != 0) {
+        ret = close (TSS2_TCTI_TABRMD_FD (context));
+        TSS2_TCTI_TABRMD_FD (context) = 0;
     }
     if (ret != 0 && ret != EBADF) {
         g_warning ("Failed to close receive pipe: %s", strerror (errno));
-    }
-    if (TSS2_TCTI_TABRMD_FD_TRANSMIT (context) != 0) {
-        ret = close (TSS2_TCTI_TABRMD_FD_TRANSMIT (context));
-        TSS2_TCTI_TABRMD_FD_TRANSMIT (context) = 0;
-    }
-    if (ret != 0 && ret != EBADF) {
-        g_warning ("Failed to close send pipe: %s", strerror (errno));
     }
     TSS2_TCTI_TABRMD_STATE (context) = TABRMD_STATE_FINAL;
     g_object_unref (TSS2_TCTI_TABRMD_PROXY (context));
@@ -333,7 +326,7 @@ tss2_tcti_tabrmd_get_poll_handles (TSS2_TCTI_CONTEXT     *context,
     }
     *num_handles = 1;
     if (handles != NULL) {
-        handles [0].fd = TSS2_TCTI_TABRMD_FD_RECEIVE (context);
+        handles [0].fd = TSS2_TCTI_TABRMD_FD (context);
     }
     return TSS2_RC_SUCCESS;
 }
@@ -480,8 +473,8 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
         g_error ("call to CreateConnection returned a NULL GUnixFDList");
     }
     gint num_handles = g_unix_fd_list_get_length (fd_list);
-    if (num_handles != 2) {
-        g_error ("CreateConnection expected to return 2 handles, received %d",
+    if (num_handles != 1) {
+        g_error ("CreateConnection expected to return 1 handles, received %d",
                  num_handles);
     }
     gint fd = g_unix_fd_list_get (fd_list, 0, &error);
@@ -493,13 +486,7 @@ tss2_tcti_tabrmd_init_full (TSS2_TCTI_CONTEXT      *context,
     if (ret == -1) {
         g_error ("failed to set O_NONBLOCK for client fd: %d", fd);
     }
-    TSS2_TCTI_TABRMD_FD_RECEIVE (context) = fd;
-    fd = g_unix_fd_list_get (fd_list, 1, &error);
-    if (fd == -1) {
-        g_error ("failed to get transmit handle from GUnixFDList: %s",
-                 error->message);
-    }
-    TSS2_TCTI_TABRMD_FD_TRANSMIT (context) = fd;
+    TSS2_TCTI_TABRMD_FD (context) = fd;
     TSS2_TCTI_TABRMD_ID (context) = id;
     g_debug ("initialized tabrmd TCTI context with id: 0x%" PRIx64,
              TSS2_TCTI_TABRMD_ID (context));

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -169,7 +169,7 @@ static int
 access_broker_setup_with_command (void **state)
 {
     test_data_t *data;
-    gint fds [2] = { 0 };
+    gint client_fd;
     guint8 *buffer;
     size_t  buffer_size;
     HandleMap *handle_map;
@@ -179,7 +179,7 @@ access_broker_setup_with_command (void **state)
     buffer_size = TPM_HEADER_SIZE;
     buffer = calloc (1, buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
     data->command = tpm2_command_new (data->connection,
                                       buffer,

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -203,18 +203,18 @@ command_source_connection_insert_test (void **state)
     CommandSource *source = data->source;
     HandleMap     *handle_map;
     Connection *connection;
-    gint ret, receive_fd, send_fd;
+    gint ret, client_fd;
 
     /* */
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&receive_fd, &send_fd, 5, handle_map);
+    connection = connection_new (&client_fd, 5, handle_map);
     g_object_unref (handle_map);
-    assert_false (FD_ISSET (connection->receive_fd, &source->receive_fdset));
+    assert_false (FD_ISSET (connection->fd, &source->receive_fdset));
     ret = thread_start(THREAD (source));
     assert_int_equal (ret, 0);
     connection_manager_insert (data->manager, connection);
     sleep (1);
-    assert_true (FD_ISSET (connection->receive_fd, &source->receive_fdset));
+    assert_true (FD_ISSET (connection->fd, &source->receive_fdset));
     connection_manager_remove (data->manager, connection);
     thread_cancel (THREAD (source));
     thread_join (THREAD (source));
@@ -268,14 +268,14 @@ command_source_process_client_fd_test (void **state)
     HandleMap   *handle_map;
     Connection *connection;
     Tpm2Command *command_out;
-    gint fds[2] = { 0, };
+    gint client_fd;
     guint8 data_in [] = { 0x80, 0x01, 0x0,  0x0,  0x0,  0x17,
                           0x0,  0x0,  0x01, 0x7a, 0x0,  0x0,
                           0x0,  0x06, 0x0,  0x0,  0x01, 0x0,
                           0x0,  0x0,  0x0,  0x7f, 0x0a };
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
         /* prime wraps */
     will_return (__wrap_connection_manager_lookup_fd, connection);

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -78,10 +78,10 @@ connection_manager_insert_test (void **state)
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL;
     HandleMap   *handle_map = NULL;
-    gint ret, receive_fd, send_fd;
+    gint ret, client_fd;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&receive_fd, &send_fd, 5, handle_map);
+    connection = connection_new (&client_fd, 5, handle_map);
     g_object_unref (handle_map);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, 0);
@@ -93,10 +93,10 @@ connection_manager_lookup_fd_test (void **state)
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL, *connection_lookup = NULL;
     HandleMap   *handle_map = NULL;
-    gint ret, receive_fd, send_fd;
+    gint ret, client_fd;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&receive_fd, &send_fd, 5, handle_map);
+    connection = connection_new (&client_fd, 5, handle_map);
     g_object_unref (handle_map);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
@@ -111,10 +111,10 @@ connection_manager_lookup_id_test (void **state)
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL, *connection_lookup = NULL;
     HandleMap   *handle_map = NULL;
-    gint ret, receive_fd, send_fd;
+    gint ret, client_fd;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&receive_fd, &send_fd, 5, handle_map);
+    connection = connection_new (&client_fd, 5, handle_map);
     g_object_unref (handle_map);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
@@ -128,11 +128,11 @@ connection_manager_remove_test (void **state)
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL;
     HandleMap   *handle_map = NULL;
-    gint ret_int, receive_fd, send_fd;
+    gint ret_int, client_fd;
     gboolean ret_bool;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&receive_fd, &send_fd, 5, handle_map);
+    connection = connection_new (&client_fd, 5, handle_map);
     g_object_unref (handle_map);
     ret_int = connection_manager_insert (manager, connection);
     assert_int_equal (ret_int, 0);

--- a/test/message-queue_unit.c
+++ b/test/message-queue_unit.c
@@ -75,10 +75,10 @@ message_queue_enqueue_dequeue_test (void **state)
     MessageQueue *queue = data->queue;
     Connection  *obj_in, *obj_out;
     HandleMap    *handle_map;
-    gint          fds[2] = { 0, };
+    gint          client_fd;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    obj_in = connection_new (&fds[0], &fds[1], 0, handle_map);
+    obj_in = connection_new (&client_fd, 0, handle_map);
     message_queue_enqueue (queue, G_OBJECT (obj_in));
     obj_out = CONNECTION (message_queue_dequeue (queue));
     /* ptr != int but they're the same size usually? */
@@ -93,15 +93,15 @@ message_queue_dequeue_order_test (void **state)
     HandleMap    *map_0, *map_1, *map_2;
     MessageQueue *queue = data->queue;
     Connection *obj_0, *obj_1, *obj_2, *obj_tmp;
-    gint fds[2] = { 0, };
+    gint client_fd;
 
     map_0 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     map_1 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     map_2 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
 
-    obj_0 = connection_new (&fds[0], &fds[1], 0, map_0);
-    obj_1 = connection_new (&fds[0], &fds[1], 0, map_1);
-    obj_2 = connection_new (&fds[0], &fds[1], 0, map_2);
+    obj_0 = connection_new (&client_fd, 0, map_0);
+    obj_1 = connection_new (&client_fd, 0, map_1);
+    obj_2 = connection_new (&client_fd, 0, map_2);
 
     message_queue_enqueue (queue, G_OBJECT (obj_0));
     message_queue_enqueue (queue, G_OBJECT (obj_1));

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -45,7 +45,7 @@ typedef struct test_data {
     TctiEcho        *tcti_echo;
     Tpm2Command     *command;
     Tpm2Response    *response;
-    gint             send_fd, recv_fd;
+    gint             client_fd;
     TPM_HANDLE       vhandles [2];
     TPMA_CC         command_attrs;
 } test_data_t;
@@ -130,7 +130,7 @@ resource_manager_setup (void **state)
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     data->access_broker = access_broker_new (TCTI (data->tcti_echo));
     data->resource_manager = resource_manager_new (data->access_broker);
-    data->connection = connection_new (&data->recv_fd, &data->send_fd, 10, handle_map);
+    data->connection = connection_new (&data->client_fd, 10, handle_map);
     g_object_unref (handle_map);
 
     *state = data;

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -37,8 +37,7 @@
 
 typedef struct {
     Connection   *connection;
-    gint          receive_fd;
-    gint          send_fd;
+    gint          client_fd;
     HandleMap    *handle_map;
     SessionEntry *session_entry;
 } test_data_t;
@@ -52,8 +51,7 @@ session_entry_setup (void **state)
 
     data = calloc (1, sizeof (test_data_t));
     data->handle_map = handle_map_new (TPM_HT_TRANSIENT, 100);
-    data->connection = connection_new (&data->receive_fd,
-                                       &data->send_fd,
+    data->connection = connection_new (&data->client_fd,
                                        CLIENT_ID,
                                        data->handle_map);
     data->session_entry = session_entry_new (data->connection, TEST_HANDLE);

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -96,7 +96,7 @@ static int
 tpm2_command_setup_base (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
@@ -104,7 +104,7 @@ tpm2_command_setup_base (void **state)
     data->buffer_size = TPM_RESPONSE_HEADER_SIZE + sizeof (TPM_HANDLE) * 3;
     data->buffer = calloc (1, data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
     *state = data;
     return 0;
@@ -167,13 +167,13 @@ static int
 tpm2_command_setup_two_handles_not_three (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     *state = data;
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
     /* */
     data->buffer_size = sizeof (two_handles_not_three);
@@ -196,7 +196,7 @@ static int
 tpm2_command_setup_with_auths (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
     TPMA_CC attributes = {
         .val = 2 << 25,
@@ -208,7 +208,7 @@ tpm2_command_setup_with_auths (void **state)
     data->buffer = calloc (1, data->buffer_size);
     memcpy (data->buffer, cmd_with_auths, sizeof (cmd_with_auths));
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
     data->command = tpm2_command_new (data->connection,
                                       data->buffer,
@@ -222,7 +222,7 @@ static int
 tpm2_command_setup_flush_context_no_handle (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
     TPMA_CC attributes = {
         .val = 2 << 25,
@@ -236,7 +236,7 @@ tpm2_command_setup_flush_context_no_handle (void **state)
             cmd_buf_context_flush_no_handle,
             data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
     data->command = tpm2_command_new (data->connection,
                                       data->buffer,
@@ -590,13 +590,13 @@ static int
 tpm2_command_setup_get_cap_no_cap (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     *state = data;
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
 
     data->buffer_size = sizeof (get_cap_no_cap);

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -51,7 +51,7 @@ static int
 tpm2_response_setup_base (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
@@ -59,7 +59,7 @@ tpm2_response_setup_base (void **state)
     data->buffer_size = TPM_RESPONSE_HEADER_SIZE + sizeof (TPM_HANDLE);
     data->buffer   = calloc (1, data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection  = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection  = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
 
     *state = data;
@@ -251,13 +251,13 @@ static int
 tpm2_response_new_rc_setup (void **state)
 {
     test_data_t *data   = NULL;
-    gint         fds[2] = { 0, };
+    gint         client_fd;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold a TPM2 header */
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection  = connection_new (&fds[0], &fds[1], 0, handle_map);
+    data->connection  = connection_new (&client_fd, 0, handle_map);
     g_object_unref (handle_map);
     data->response = tpm2_response_new_rc (data->connection, TPM_RC_BINDING);
 


### PR DESCRIPTION
The initial implementation of the communication mechanism used to send
command / response buffers between the daemon and the TCTI library was
pipe2(2). This works well but it requires that we manage two fds on both
ends of the communication channel. As we work toward a more generic /
flexible IPC front end getting the implementation down to a single fd
will make things easier to manage.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>