### PR TITLE
util: Use TEMP_RETRY_FAIL when calling 'write'.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -95,9 +95,9 @@ write_all (const gint    fd,
                  size - written_total,
                  (uintptr_t)buf + written_total,
                  fd);
-        written = write (fd,
-                         buf  + written_total,
-                         size - written_total);
+        written = TEMP_FAILURE_RETRY (write (fd,
+                                             buf  + written_total,
+                                             size - written_total));
         switch (written) {
         case -1:
             g_warning ("failed to write to fd %d: %s", fd, strerror (errno));


### PR DESCRIPTION
This should handle temporary interrupts that may happen while we're
in the write syscall. Not sure why we were only doing this for the
read call.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>