### PR TITLE
Revert "travis: Build against TSS master branch & acount for upstream…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,15 +49,12 @@ install:
   - cmake ../ -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_BUILD_TYPE=Release
   - make -j$(nproc) install
   - popd
-  - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
+  - git clone -b 1.x --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
   - ./bootstrap
   - ./configure --prefix=${PREFIX}
   - make -j$(nproc) install
   - popd
-  - cat ${DESTDIR}${PREFIX}/lib/*.la
-  - sed -i -e "s&\(\/usr\/lib\/lib.*\.la\)&$(pwd)/destdir\1&" ${DESTDIR}${PREFIX}/lib/*.la
-  - cat ${DESTDIR}${PREFIX}/lib/*.la
   - wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz
   - sha256sum ibmtpm974.tar.gz | grep -q ^8e45d86129a0adb95fee4cee51f4b1e5b2d81ed3e55af875df53f98f39eb7ad7
   - mkdir ibmtpm

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ PKG_CHECK_MODULES([DBUS], [dbus-1])
 PKG_CHECK_MODULES([GIO], [gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 PKG_CHECK_MODULES([GOBJECT], [gobject-2.0])
-PKG_CHECK_MODULES([SAPI],[sapi >= 2.0.0])
+PKG_CHECK_MODULES([SAPI],[sapi < 2.0.0])
 AC_ARG_VAR([GDBUS_CODEGEN],[The gdbus-codegen executable.])
 AC_PATH_PROG([GDBUS_CODEGEN], [`$PKG_CONFIG --variable=gdbus_codegen gio-2.0`])
 if test -z "$GDBUS_CODEGEN"; then

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -104,7 +104,7 @@
 #define AUTH_SESSION_ATTRS_END_OFFSET(cmd, index) \
     (AUTH_SESSION_ATTRS_OFFSET (cmd, index) + sizeof (UINT8))
 #define AUTH_GET_SESSION_ATTRS(cmd, index) \
-    ((TPMA_SESSION)(UINT8)cmd->buffer [AUTH_SESSION_ATTRS_OFFSET (cmd, index)])
+    ((TPMA_SESSION)(UINT32)cmd->buffer [AUTH_SESSION_ATTRS_OFFSET (cmd, index)])
 /* authorization */
 #define AUTH_AUTH_SIZE_OFFSET(cmd, index) \
     (AUTH_SESSION_ATTRS_END_OFFSET (cmd, index))
@@ -631,13 +631,13 @@ tpm2_command_get_auth_attrs (Tpm2Command *command,
     size_t attrs_end;
 
     if (command == NULL) {
-        return (TPMA_SESSION)(UINT8)0;
+        return (TPMA_SESSION)(UINT32)0;
     }
     attrs_end = AUTH_SESSION_ATTRS_END_OFFSET (command, auth_offset);
     if (attrs_end > command->buffer_size) {
         g_warning ("%s attempt to access session attributes overruns command "
                    "buffer", __func__);
-        return (TPMA_SESSION)(UINT8)0;
+        return (TPMA_SESSION)(UINT32)0;
     }
     return AUTH_GET_SESSION_ATTRS (command, auth_offset);
 }


### PR DESCRIPTION
… ABI changes."

This belongs in master, not the 1.x release branch. The 1.x branch
tracks 1.x from the TSS.

This reverts commit 1f6fa70f8b40ef3e38d38d60e9683ab076a16b1f.