### PR TITLE
build: Generate version number from git data in bootstrap.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,7 +120,8 @@ EXTRA_DIST = \
     CONTRIBUTING.md \
     INSTALL.md \
     LICENSE \
-    README.md
+    README.md \
+    VERSION
 
 CLEANFILES = \
     $(man3_MANS) \

--- a/bootstrap
+++ b/bootstrap
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+git describe --tags --always --dirty > VERSION
 autoreconf --install --sym

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([tpm2-abrmd],
-        [1.1.1],
+        [m4_esyscmd_s([cat ./VERSION])],
         [https://github.com/01org/tpm2-abrmd/issues],
         [],
         [https://github.com/01org/tpm2-abrmd])


### PR DESCRIPTION
This is a good middle ground between doing this in the configure script
and having a static version string. Github source zip files will still
not work, but this is compatible with the tarballs generated by the
'distcheck' target.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>