### PR TITLE
Use GSocket in Connection instead of raw FD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -366,7 +366,7 @@ test_tpm2_response_unit_SOURCES = test/tpm2-response_unit.c
 
 test_util_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_util_unit_LDADD  = $(CMOCKA_LIBS) $(GLIB_LIBS) $(libutil)
-test_util_unit_LDFLAGS = -Wl,--wrap=read,--wrap=write
+test_util_unit_LDFLAGS = -Wl,--wrap=g_socket_receive,--wrap=g_socket_send
 test_util_unit_SOURCES = test/util_unit.c
 
 test_message_queue_unit_CFLAGS  = $(UNIT_AM_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -327,7 +327,7 @@ test_command_attrs_unit_SOURCES  = test/command-attrs_unit.c
 
 test_command_source_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_command_source_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(SAPI_LIBS) $(PTHREAD_LIBS) $(GOBJECT_LIBS) $(libutil)
-test_command_source_unit_LDFLAGS = -Wl,--wrap=connection_manager_lookup_fd,--wrap=sink_enqueue,--wrap=read_data
+test_command_source_unit_LDFLAGS = -Wl,--wrap=connection_manager_lookup_fd,--wrap=sink_enqueue,--wrap=read_tpm_buffer_alloc
 test_command_source_unit_SOURCES = test/command-source_unit.c
 
 test_handle_map_entry_unit_CFLAGS  = $(UNIT_AM_CFLAGS)

--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -118,12 +118,12 @@ connection_manager_new (guint max_connections)
      */
     mgr->connection_from_fd_table =
         g_hash_table_new_full (g_int_hash,
-                               connection_equal_fd,
+                               g_int_equal,
                                NULL,
                                NULL);
     mgr->connection_from_id_table =
         g_hash_table_new_full (g_int64_hash,
-                               connection_equal_id,
+                               g_int64_equal,
                                NULL,
                                (GDestroyNotify)g_object_unref);
     return mgr;

--- a/src/connection.h
+++ b/src/connection.h
@@ -29,6 +29,7 @@
 
 #include <glib.h>
 #include <glib-object.h>
+#include <gio/gio.h>
 
 #include "handle-map.h"
 
@@ -40,6 +41,7 @@ typedef struct _ConnectionClass {
 
 typedef struct _Connection {
     GObject             parent_instance;
+    GSocket            *socket;
     gint                fd;
     guint64             id;
     HandleMap          *transient_handle_map;
@@ -56,13 +58,9 @@ GType            connection_get_type     (void);
 Connection*      connection_new          (gint            *client_fd,
                                           guint64          id,
                                           HandleMap       *transient_handle_map);
-gboolean         connection_equal_fd     (gconstpointer    a,
-                                          gconstpointer    b);
-gboolean         connection_equal_id     (gconstpointer    a,
-                                          gconstpointer    b);
 gpointer         connection_key_fd       (Connection      *session);
 gpointer         connection_key_id       (Connection      *session);
-gint             connection_fd           (Connection      *session);
+GSocket*         connection_get_gsocket  (Connection      *connection);
 HandleMap*       connection_get_trans_map(Connection      *session);
 /* not part of the public API but included here for testing */
 int              create_fd_pair (int *client_fd,

--- a/src/response-sink.c
+++ b/src/response-sink.c
@@ -207,16 +207,18 @@ response_sink_process_response (Tpm2Response *response)
     guint32      size    = tpm2_response_get_size (response);
     guint8      *buffer  = tpm2_response_get_buffer (response);
     Connection  *connection = tpm2_response_get_connection (response);
-    gint         fd      = connection_fd (connection);
+    GSocket     *socket  = connection_get_gsocket (connection);
 
     g_debug ("response_sink_thread got response: 0x%" PRIxPTR " size %d",
              (uintptr_t)response, size);
     g_debug ("  writing 0x%x bytes", size);
     g_debug_bytes (buffer, size, 16, 4);
-    written = write_all (fd, buffer, size);
+    written = write_all (socket, buffer, size);
     if (written <= 0)
-        g_warning ("write failed (%zu) on fd %d for connection 0x%" PRIxPTR ": %s",
-                   written, fd, (uintptr_t)connection, strerror (errno));
+        g_warning ("write failed (%zu) on socket 0x%" PRIxPTR " for connection"
+                   "  0x%" PRIxPTR ": %s",
+                   written, (uintptr_t)socket, (uintptr_t)connection,
+                   strerror (errno));
     g_object_unref (connection);
 
     return written;

--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -40,8 +40,8 @@
 
 #define TSS2_TCTI_TABRMD_ID(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->id
-#define TSS2_TCTI_TABRMD_FD(context) \
-    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->fd
+#define TSS2_TCTI_TABRMD_SOCKET(context) \
+    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->socket
 #define TSS2_TCTI_TABRMD_PROXY(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->proxy
 #define TSS2_TCTI_TABRMD_HEADER(context) \
@@ -90,7 +90,7 @@ typedef enum {
 typedef struct {
     TSS2_TCTI_CONTEXT_COMMON_V1    common;
     guint64                        id;
-    int                            fd;
+    GSocket                       *socket;
     TctiTabrmd                    *proxy;
     tpm_header_t                   header;
     tcti_tabrmd_state_t            state;

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -478,6 +478,7 @@ tpm2_command_get_flush_handle (Tpm2Command *command,
         return RM_RC (TPM_RC_TYPE);
     }
     if (command->buffer_size < TPM_HEADER_SIZE + sizeof (TPM_HANDLE)) {
+        g_warning ("%s: command buffer_size insufficient", __func__);
         *handle = 0;
         return RM_RC (TPM_RC_INSUFFICIENT);
     }

--- a/src/util.h
+++ b/src/util.h
@@ -28,7 +28,7 @@
 #define UTIL_H
 
 #include <glib.h>
-#include <sys/types.h>
+#include <gio/gio.h>
 #include <sapi/tpm20.h>
 
 #include "control-message.h"
@@ -54,14 +54,14 @@
 #define TPMA_CC_RES(attrs)         (attrs.val & 0xc0000000)
 */
 
-ssize_t     write_all                       (gint const        fd,
-                                             void const       *buf,
-                                             size_t const      size);
-int         read_data                       (int               fd,
+ssize_t     write_all                       (GSocket          *socket,
+                                             const uint8_t    *buf,
+                                             const size_t      size);
+int         read_data                       (GSocket          *socket,
                                              size_t           *index,
                                              uint8_t          *buf,
                                              size_t            count);
-int         read_tpm_buffer                 (int               fd,
+int         read_tpm_buffer                 (GSocket          *socket,
                                              size_t           *index,
                                              uint8_t          *buf,
                                              size_t            buf_size);
@@ -70,6 +70,4 @@ void        g_debug_bytes                   (uint8_t const    *byte_array,
                                              size_t            width,
                                              size_t            indent);
 void        g_debug_tpma_cc                 (TPMA_CC           tpma_cc);
-int         set_flags                       (const int         fd,
-                                             const int         flags);
 #endif /* UTIL_H */

--- a/src/util.h
+++ b/src/util.h
@@ -65,6 +65,8 @@ int         read_tpm_buffer                 (GSocket          *socket,
                                              size_t           *index,
                                              uint8_t          *buf,
                                              size_t            buf_size);
+uint8_t*    read_tpm_buffer_alloc           (GSocket          *socket,
+                                             size_t           *buf_size);
 void        g_debug_bytes                   (uint8_t const    *byte_array,
                                              size_t            array_size,
                                              size_t            width,

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -68,7 +68,6 @@ __wrap_read_data (int                       fd,
                   uint8_t                  *buf,
                   size_t                    count)
 {
-    g_debug ("__wrap_read_data");
     memcpy (&buf[*index], mock_type(uint8_t*), count);
     *index = mock_type (size_t);
     return mock_type (int);

--- a/test/connection_unit.c
+++ b/test/connection_unit.c
@@ -152,22 +152,6 @@ connection_key_id_test (void **state)
     assert_int_equal (connection->id, *key);
 }
 
-static void
-connection_equal_fd_test (void **state)
-{
-    connection_test_data_t *data = (connection_test_data_t*)*state;
-    const gint *key = connection_key_fd (data->connection);
-    assert_true (connection_equal_fd (key, connection_key_fd (data->connection)));
-}
-
-static void
-connection_equal_id_test (void **state)
-{
-    connection_test_data_t *data = (connection_test_data_t*)*state;
-    const guint64 *key = connection_key_id (data->connection);
-    assert_true (connection_equal_id (key, connection_key_id (data->connection)));
-}
-
 /* connection_client_to_server_test begin
  * This test creates a connection and communicates with it as though the pipes
  * that are created as part of connection setup.
@@ -211,12 +195,6 @@ main(int argc, char* argv[])
                                          connection_setup,
                                          connection_teardown),
         cmocka_unit_test_setup_teardown (connection_key_id_test,
-                                         connection_setup,
-                                         connection_teardown),
-        cmocka_unit_test_setup_teardown (connection_equal_fd_test,
-                                         connection_setup,
-                                         connection_teardown),
-        cmocka_unit_test_setup_teardown (connection_equal_id_test,
                                          connection_setup,
                                          connection_teardown),
         cmocka_unit_test_setup_teardown (connection_client_to_server_test,

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -798,7 +798,7 @@ tcti_tabrmd_receive_error_first_read_test (void **state)
      */
     will_return (__wrap_read_data, buffer_in);
     will_return (__wrap_read_data, 0);
-    will_return (__wrap_read_data, EAGAIN);
+    will_return (__wrap_read_data, G_IO_ERROR_WOULD_BLOCK);
 
     rc = tss2_tcti_receive (data->context,
                             &size,
@@ -868,7 +868,7 @@ tcti_tabrmd_receive_two_reads_header_test (void **state)
     */
     will_return (__wrap_read_data, buffer_in);
     will_return (__wrap_read_data, TPM_HEADER_SIZE / 2);
-    will_return (__wrap_read_data, EAGAIN);
+    will_return (__wrap_read_data, G_IO_ERROR_WOULD_BLOCK);
 
     rc = tss2_tcti_receive (data->context,
                             &size,
@@ -1072,12 +1072,13 @@ tcti_tabrmd_get_poll_handles_handles_test (void **state)
     TSS2_TCTI_POLL_HANDLE handles[5] = { 0 };
     size_t num_handles = 5;
     TSS2_RC rc;
+    int fd;
 
     rc = tss2_tcti_get_poll_handles (data->context, handles, &num_handles);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (1, num_handles);
-    assert_int_equal (handles [0].fd,
-                      TSS2_TCTI_TABRMD_FD (data->context));
+    fd = g_socket_get_fd (TSS2_TCTI_TABRMD_SOCKET (data->context));
+    assert_int_equal (handles [0].fd, fd);
 }
 /*
  * This test sets up the call_set_locality mock function to return values

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -39,11 +39,25 @@
 #define READ_SIZE  UTIL_BUF_SIZE
 #define WRITE_SIZE 10
 
-ssize_t
-__wrap_write (gint         fd,
-              const void  *buf,
-              size_t       count)
+#define UTIL_UNIT_ERROR util_unit_error_quark ()
+
+GQuark
+util_unit_error_quark (void)
 {
+    return g_quark_from_static_string ("util-unit-error-quark");
+}
+
+ssize_t
+__wrap_g_socket_send (gint           fd,
+                      const void    *buf,
+                      size_t         count,
+                      GCancellable  *cancellable,
+                      GError       **error)
+{
+    GError *error_tmp = mock_type (GError*);
+    if (error_tmp != NULL && error != NULL) {
+        *error = error_tmp;
+    }
     return (ssize_t) mock ();
 }
 
@@ -52,7 +66,8 @@ write_in_one (void **state)
 {
     ssize_t written;
 
-    will_return (__wrap_write, WRITE_SIZE);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, WRITE_SIZE);
     written = write_all (0, NULL, WRITE_SIZE);
     assert_int_equal (written, WRITE_SIZE);
 }
@@ -62,8 +77,10 @@ write_in_two (void **state)
 {
     ssize_t written;
 
-    will_return (__wrap_write, 5);
-    will_return (__wrap_write, 5);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, 5);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, 5);
     written = write_all (0, NULL, WRITE_SIZE);
     assert_int_equal (written, WRITE_SIZE);
 }
@@ -73,9 +90,12 @@ write_in_three (void **state)
 {
     ssize_t written;
 
-    will_return (__wrap_write, 3);
-    will_return (__wrap_write, 3);
-    will_return (__wrap_write, 4);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, 3);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, 3);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, 4);
     written = write_all (0, NULL, WRITE_SIZE);
     assert_int_equal (written, WRITE_SIZE);
 }
@@ -84,8 +104,14 @@ void
 write_error (void **state)
 {
     ssize_t written;
+    GError *error;
 
-    will_return (__wrap_write, -1);
+    /* this is free'd by the 'write_all' function */
+    error = g_error_new (UTIL_UNIT_ERROR,
+                         G_IO_ERROR_WOULD_BLOCK,
+                         "g-io-error-would-block");
+    will_return (__wrap_g_socket_send, error);
+    will_return (__wrap_g_socket_send, -1);
     written = write_all (0, NULL, WRITE_SIZE);
     assert_int_equal (written, -1);
 }
@@ -95,7 +121,8 @@ write_zero (void **state)
 {
     ssize_t written;
 
-    will_return (__wrap_write, 0);
+    will_return (__wrap_g_socket_send, NULL);
+    will_return (__wrap_g_socket_send, 0);
     written = write_all (0, NULL, WRITE_SIZE);
     assert_int_equal (written, 0);
 }
@@ -104,26 +131,30 @@ write_zero (void **state)
  * queue:
  *   input buffer
  *   offset into input buffer where read starts
- *   errno
+ *   GError
  *   return value
  */
 ssize_t
-__wrap_read (int     fd,
-             void   *buf,
-             size_t  count)
+__wrap_g_socket_receive (GSocket       *socket,
+                         gint          *buf,
+                         size_t         count,
+                         GCancellable  *cancellable,
+                         GError       **error)
 {
     uint8_t *buf_in    = mock_type (uint8_t*);
     size_t   buf_index = mock_type (size_t);
-    int      errno_in  = mock_type (int);
+    GError  *error_in  = mock_type (GError*);
     ssize_t  ret       = mock_type (ssize_t);
 
+    if (error_in != NULL && error != NULL) {
+        *error = error_in;
+    }
     /* be careful comparint signed to unsigned values */
     if (ret > 0) {
         assert_true (ret <= (ssize_t)count);
         memcpy (buf, &buf_in [buf_index], ret);
     }
 
-    errno = errno_in;
     return ret;
 }
 /* global static input array used by read_data* tests */
@@ -139,7 +170,7 @@ static uint8_t buf_in [MAX_BUF] = {
  * Data structure to hold data for read tests.
  */
 typedef struct {
-    int     fd;
+    GSocket *socket;
     size_t  index;
     uint8_t buf_out [MAX_BUF];
     size_t  buf_size;
@@ -179,16 +210,17 @@ read_data_success_test (void **state)
     int ret = 0;
 
     /* prime the wrap queue for a successful read */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->index);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->index);
+    will_return (__wrap_g_socket_receive, NULL);
+    will_return (__wrap_g_socket_receive, data->buf_size);
 
-    ret = read_data (data->fd, &data->index, data->buf_out, data->buf_size);
+    ret = read_data (data->socket, &data->index, data->buf_out, data->buf_size);
     assert_int_equal (ret, 0);
     assert_int_equal (data->index, data->buf_size);
     assert_memory_equal (data->buf_out, buf_in, data->buf_size);
 }
+
 /*
  * This tests a simple error case where read returns -1 and errno is set to
  * EIO. In this case the index should remain unchanged (0).
@@ -198,14 +230,18 @@ read_data_error_test (void **state)
 {
     data_t *data = *state;
     int ret = 0;
+    GError *error;
 
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->index);
-    will_return (__wrap_read, EIO);
-    will_return (__wrap_read, -1);
+    error = g_error_new (UTIL_UNIT_ERROR,
+                         G_IO_ERROR_WOULD_BLOCK,
+                         "g-io-error-would-block");
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->index);
+    will_return (__wrap_g_socket_receive, error);
+    will_return (__wrap_g_socket_receive, -1);
 
-    ret = read_data (data->fd, &data->index, data->buf_out, data->buf_size);
-    assert_int_equal (ret, EIO);
+    ret = read_data (data->socket, &data->index, data->buf_out, data->buf_size);
+    assert_int_equal (ret, G_IO_ERROR_WOULD_BLOCK);
     assert_int_equal (data->index, 0);
 }
 /*
@@ -220,17 +256,17 @@ read_data_short_success_test (void **state)
     int ret = 0;
 
     /* prime the wrap queue for a short read (half the requested size) */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->index);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size / 2);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->index);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, data->buf_size / 2);
     /* do it again for the second half of the read */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->buf_size / 2);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size / 2);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->buf_size / 2);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, data->buf_size / 2);
 
-    ret = read_data (data->fd, &data->index, data->buf_out, data->buf_size);
+    ret = read_data (data->socket, &data->index, data->buf_out, data->buf_size);
     assert_int_equal (ret, 0);
     assert_int_equal (data->index, data->buf_size);
     assert_memory_equal (data->buf_out, buf_in, data->buf_size);
@@ -244,23 +280,27 @@ read_data_short_err_test (void **state)
 {
     data_t *data = *state;
     int ret = 0;
+    GError *error;
 
     /*
      * Prime the wrap queue for another short read, again half the requested
      * size.
      */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->index);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size / 2);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->index);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, data->buf_size / 2);
     /* */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->buf_size / 2);
-    will_return (__wrap_read, EAGAIN);
-    will_return (__wrap_read, -1);
+    error = g_error_new (UTIL_UNIT_ERROR,
+                         G_IO_ERROR_WOULD_BLOCK,
+                         "g-io-error-would-block");
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->buf_size / 2);
+    will_return (__wrap_g_socket_receive, error);
+    will_return (__wrap_g_socket_receive, -1);
     /* read the second half of the buffer, the index maintains the state */
-    ret = read_data (data->fd, &data->index, data->buf_out, data->buf_size);
-    assert_int_equal (ret, EAGAIN);
+    ret = read_data (data->socket, &data->index, data->buf_out, data->buf_size);
+    assert_int_equal (ret, G_IO_ERROR_WOULD_BLOCK);
     assert_int_equal (data->index, data->buf_size / 2);
     assert_memory_equal (data->buf_out, buf_in, data->buf_size / 2);
 }
@@ -274,44 +314,14 @@ read_data_eof_test (void **state)
     data_t *data = *state;
     int ret = 0;
 
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->index);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 0);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->index);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 0);
 
-    ret = read_data (data->fd, &data->index, data->buf_out, data->buf_size);
+    ret = read_data (data->socket, &data->index, data->buf_out, data->buf_size);
     assert_int_equal (ret, -1);
     assert_int_equal (data->index, 0);
-}
-/*
- * This test causes the first call to 'read' to result in an error with errno
- * set to EINTR. This is caused by interrupted system calls. The call should
- * be retried. The second read succeeds with the whole of the buffer read.
- */
-static void
-read_data_eintr_test (void **state)
-{
-    data_t *data = *state;
-    int ret = 0;
-
-    /*
-     * Prime the wrap queue for another short read, again half the requested
-     * size.
-     */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, EINTR);
-    will_return (__wrap_read, -1);
-    /* */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size);
-    /* read the second half of the buffer, the index maintains the state */
-    ret = read_data (data->fd, &data->index, data->buf_out, data->buf_size);
-    assert_int_equal (ret, 0);
-    assert_int_equal (data->index, data->buf_size);
-    assert_memory_equal (data->buf_out, buf_in, data->buf_size);
 }
 /*
  * This test covers the common case when reading a tpm command / response
@@ -326,17 +336,17 @@ read_tpm_buf_success_test (void **state)
     int ret = 0;
 
     /* prime read to successfully produce the header */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 10);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 10);
     /* prime read to successfully produce the rest of the buffer */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 10);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size - 10);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 10);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, data->buf_size - 10);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
@@ -359,12 +369,12 @@ read_tpm_buf_header_only_success_test (void **state)
 
     /* prime read to successfully produce the header */
     data->buf_size = 10;
-    will_return (__wrap_read, buf);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 10);
+    will_return (__wrap_g_socket_receive, buf);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 10);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
@@ -382,7 +392,7 @@ read_tpm_buf_lt_header_test (void **state)
     data_t *data = *state;
     int ret = 0;
 
-    ret = read_tpm_buffer (data->fd, &data->index, data->buf_out, 8);
+    ret = read_tpm_buffer (data->socket, &data->index, data->buf_out, 8);
     assert_int_equal (ret, EPROTO);
     assert_int_equal (data->index, 0);
 }
@@ -392,26 +402,30 @@ read_tpm_buf_short_header_test (void **state)
 {
     data_t *data = *state;
     int ret = 0;
+    GError *error;
 
     /*
      * Prime read to successfully produce 4 bytes. This is a short read to
      * exercise the error handling path in the function under test.
      */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 4);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 4);
 
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 4);
-    will_return (__wrap_read, EWOULDBLOCK);
-    will_return (__wrap_read, -1);
+    error = g_error_new (UTIL_UNIT_ERROR,
+                         G_IO_ERROR_WOULD_BLOCK,
+                         "g-io-error-would-block");
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 4);
+    will_return (__wrap_g_socket_receive, error);
+    will_return (__wrap_g_socket_receive, -1);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
-    assert_int_equal (ret, EWOULDBLOCK);
+    assert_int_equal (ret, G_IO_ERROR_WOULD_BLOCK);
     assert_int_equal (data->index, 4);
     assert_memory_equal (data->buf_out, buf_in, data->index);
 }
@@ -429,12 +443,12 @@ read_tpm_buf_lt_body_test (void **state)
      * Prime read to successfully produce 10 bytes. This is the number of
      * bytes that the first 'read' syscall is asked to produce (header).
      */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, data->index);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 10);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, data->index);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 10);
 
-    ret = read_tpm_buffer (data->fd, &data->index, data->buf_out, 11);
+    ret = read_tpm_buffer (data->socket, &data->index, data->buf_out, 11);
     assert_int_equal (ret, EPROTO);
     assert_int_equal (data->index, 10);
     assert_memory_equal (data->buf_out, buf_in, 10);
@@ -454,22 +468,22 @@ read_tpm_buf_short_body_test (void **state)
      * Prime read to successfully produce 10 bytes. This is the number of
      * bytes that the first 'read' syscall is asked to produce (header).
      */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 10);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 10);
     /* Now cause a short read when getting the body of the buffer. */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 10);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 5);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 10);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 5);
     /* And then the rest of the buffer */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 15);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, data->buf_size - 15);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 15);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, data->buf_size - 15);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
@@ -500,17 +514,17 @@ read_tpm_buf_populated_header_half_test (void **state)
     /* prime read to successfully produce the header */
     data->index = 4;
     /* read the last 6 bytes of the header */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 4);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 6);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 4);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 6);
     /* read the rest of the body (26 - 10) */
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 10);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 16);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 10);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 16);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
@@ -539,7 +553,7 @@ read_tpm_buf_populated_header_only_test (void **state)
     data->index = 10;
     memcpy (data->buf_out, buf, data->buf_size);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
@@ -564,12 +578,12 @@ read_tpm_buf_populated_body_test (void **state)
     /* prime read to successfully produce the header */
     data->index = 16;
 
-    will_return (__wrap_read, buf_in);
-    will_return (__wrap_read, 16);
-    will_return (__wrap_read, 0);
-    will_return (__wrap_read, 10);
+    will_return (__wrap_g_socket_receive, buf_in);
+    will_return (__wrap_g_socket_receive, 16);
+    will_return (__wrap_g_socket_receive, 0);
+    will_return (__wrap_g_socket_receive, 10);
 
-    ret = read_tpm_buffer (data->fd,
+    ret = read_tpm_buffer (data->socket,
                            &data->index,
                            data->buf_out,
                            data->buf_size);
@@ -602,9 +616,6 @@ main (gint    argc,
                                          read_data_setup,
                                          read_data_teardown),
         cmocka_unit_test_setup_teardown (read_data_eof_test,
-                                         read_data_setup,
-                                         read_data_teardown),
-        cmocka_unit_test_setup_teardown (read_data_eintr_test,
                                          read_data_setup,
                                          read_data_teardown),
         /* read_tpm_buf tests */


### PR DESCRIPTION
There's still a bunch of code that relies on the raw FD like the poll stuff and the connection lookup function but this is a start. Next step is to replace the poll loop with some GSource async IO magic and get rid of the FD usage completely.