### PR TITLE
.gitignore: Ignore VERSION file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ test/integration/*
 !test/integration/*.h
 dist/*.preset
 dist/*.service
+VERSION


### PR DESCRIPTION
Changes to the bootstrap script in 7f0d83903b842fc806e007d0c31c2f97cb2d7bd7
cause this file to be generated and shipped in release tarballs.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>