### PR TITLE
Connection: Invert dependency in _new function on connection mechanism.

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -54,16 +54,11 @@ typedef struct _Connection {
 #define CONNECTION_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj),  TYPE_CONNECTION, ConnectionClass))
 
 GType            connection_get_type     (void);
-Connection*      connection_new          (gint            *client_fd,
+Connection*      connection_new          (GSocket         *socket,
                                           guint64          id,
                                           HandleMap       *transient_handle_map);
 gpointer         connection_key_socket   (Connection      *session);
 gpointer         connection_key_id       (Connection      *session);
 GSocket*         connection_get_gsocket  (Connection      *connection);
 HandleMap*       connection_get_trans_map(Connection      *session);
-/* not part of the public API but included here for testing */
-int              create_fd_pair (int *client_fd,
-                                 int *server_fd,
-                                 int  flags);
-
 #endif /* CONNECTION_H */

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -49,6 +49,7 @@
 #include "source-interface.h"
 #include "tabrmd-generated.h"
 #include "tcti-options.h"
+#include "util.h"
 
 #ifdef G_OS_UNIX
 #include <gio/gunixfdlist.h>
@@ -255,6 +256,7 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
     HandleMap   *handle_map = NULL;
     Connection *connection = NULL;
     gint client_fd = 0, ret = 0;
+    GSocket *server_socket;
     GVariant *response_variants[2], *response_tuple;
     GUnixFDList *fd_list = NULL;
     guint64 id = 0, id_pid_mix = 0;
@@ -292,8 +294,10 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
     handle_map = handle_map_new (TPM_HT_TRANSIENT, data->options.max_transient_objects);
     if (handle_map == NULL)
         g_error ("Failed to allocate new HandleMap");
-    connection = connection_new (&client_fd, id_pid_mix, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    connection = connection_new (server_socket, id_pid_mix, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     if (connection == NULL)
         g_error ("Failed to allocate new connection.");
     g_debug ("Created connection with fd: %d and id: 0x%" PRIx64,

--- a/src/util.h
+++ b/src/util.h
@@ -71,5 +71,9 @@ void        g_debug_bytes                   (uint8_t const    *byte_array,
                                              size_t            array_size,
                                              size_t            width,
                                              size_t            indent);
+GSocket*    create_socket_connection        (int              *client_fd);
+int         create_socket_pair              (int              *fd_a,
+                                             int              *fd_b,
+                                             int               flags);
 void        g_debug_tpma_cc                 (TPMA_CC           tpma_cc);
 #endif /* UTIL_H */

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -34,6 +34,7 @@
 #include "tcti-echo.h"
 #include "tpm2-header.h"
 #include "tpm2-response.h"
+#include "util.h"
 
 #define MAX_COMMAND_VALUE 2048
 #define MAX_RESPONSE_VALUE 1024
@@ -173,14 +174,17 @@ access_broker_setup_with_command (void **state)
     guint8 *buffer;
     size_t  buffer_size;
     HandleMap *handle_map;
+    GSocket   *server_socket;
 
     access_broker_setup_with_init (state);
     data = (test_data_t*)*state;
     buffer_size = TPM_HEADER_SIZE;
     buffer = calloc (1, buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     data->command = tpm2_command_new (data->connection,
                                       buffer,
                                       buffer_size,

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -41,6 +41,7 @@
 
 #include "connection.h"
 #include "connection-manager.h"
+#include "util.h"
 
 static void
 connection_manager_allocate_test (void **state)
@@ -79,10 +80,13 @@ connection_manager_insert_test (void **state)
     Connection *connection = NULL;
     HandleMap   *handle_map = NULL;
     gint ret, client_fd;
+    GSocket *server_socket;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&client_fd, 5, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    connection = connection_new (server_socket, 5, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, 0);
 }
@@ -94,10 +98,13 @@ connection_manager_lookup_fd_test (void **state)
     Connection *connection = NULL, *connection_lookup = NULL;
     HandleMap   *handle_map = NULL;
     gint ret, client_fd;
+    GSocket *server_socket;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&client_fd, 5, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    connection = connection_new (server_socket, 5, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
     connection_lookup = connection_manager_lookup_socket (manager,
@@ -112,11 +119,14 @@ connection_manager_lookup_id_test (void **state)
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL, *connection_lookup = NULL;
     HandleMap   *handle_map = NULL;
+    GSocket     *server_socket;
     gint ret, client_fd;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&client_fd, 5, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    connection = connection_new (server_socket, 5, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
     connection_lookup = connection_manager_lookup_id (manager, *(int*)connection_key_id (connection));
@@ -128,13 +138,16 @@ connection_manager_remove_test (void **state)
 {
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL;
+    GSocket     *server_socket;
     HandleMap   *handle_map = NULL;
     gint ret_int, client_fd;
     gboolean ret_bool;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    connection = connection_new (&client_fd, 5, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    connection = connection_new (server_socket, 5, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     ret_int = connection_manager_insert (manager, connection);
     assert_int_equal (ret_int, 0);
     ret_bool = connection_manager_remove (manager, connection);

--- a/test/message-queue_unit.c
+++ b/test/message-queue_unit.c
@@ -34,6 +34,7 @@
 #include "message-queue.h"
 #include "connection.h"
 #include "control-message.h"
+#include "util.h"
 
 typedef struct msgq_test_data {
     MessageQueue *queue;
@@ -76,14 +77,17 @@ message_queue_enqueue_dequeue_test (void **state)
     Connection  *obj_in, *obj_out;
     HandleMap    *handle_map;
     gint          client_fd;
+    GSocket      *server_socket;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    obj_in = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    obj_in = connection_new (server_socket, 0, handle_map);
     message_queue_enqueue (queue, G_OBJECT (obj_in));
     obj_out = CONNECTION (message_queue_dequeue (queue));
     /* ptr != int but they're the same size usually? */
     assert_int_equal (obj_in, obj_out);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
 }
 
 static void
@@ -94,14 +98,21 @@ message_queue_dequeue_order_test (void **state)
     MessageQueue *queue = data->queue;
     Connection *obj_0, *obj_1, *obj_2, *obj_tmp;
     gint client_fd;
+    GSocket *server_socket;
 
     map_0 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     map_1 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     map_2 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
 
-    obj_0 = connection_new (&client_fd, 0, map_0);
-    obj_1 = connection_new (&client_fd, 0, map_1);
-    obj_2 = connection_new (&client_fd, 0, map_2);
+    server_socket = create_socket_connection (&client_fd);
+    obj_0 = connection_new (server_socket, 0, map_0);
+    g_object_unref (server_socket);
+    server_socket = create_socket_connection (&client_fd);
+    obj_1 = connection_new (server_socket, 0, map_1);
+    g_object_unref (server_socket);
+    server_socket = create_socket_connection (&client_fd);
+    obj_2 = connection_new (server_socket, 0, map_2);
+    g_object_unref (server_socket);
 
     message_queue_enqueue (queue, G_OBJECT (obj_0));
     message_queue_enqueue (queue, G_OBJECT (obj_1));

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -37,6 +37,7 @@
 #include "source-interface.h"
 #include "tpm2-command.h"
 #include "tpm2-header.h"
+#include "util.h"
 
 typedef struct test_data {
     AccessBroker    *access_broker;
@@ -119,6 +120,7 @@ static int
 resource_manager_setup (void **state)
 {
     test_data_t *data;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
     TSS2_RC rc;
 
@@ -130,8 +132,10 @@ resource_manager_setup (void **state)
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     data->access_broker = access_broker_new (TCTI (data->tcti_echo));
     data->resource_manager = resource_manager_new (data->access_broker);
-    data->connection = connection_new (&data->client_fd, 10, handle_map);
+    server_socket = create_socket_connection (&data->client_fd);
+    data->connection = connection_new (server_socket, 10, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
 
     *state = data;
     return 0;

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -31,6 +31,7 @@
 #include <cmocka.h>
 
 #include "session-entry.h"
+#include "util.h"
 
 #define CLIENT_ID        1ULL
 #define TEST_HANDLE      0x03000000
@@ -48,10 +49,12 @@ static int
 session_entry_setup (void **state)
 {
     test_data_t *data   = NULL;
+    GSocket *server_socket;
 
     data = calloc (1, sizeof (test_data_t));
     data->handle_map = handle_map_new (TPM_HT_TRANSIENT, 100);
-    data->connection = connection_new (&data->client_fd,
+    server_socket = create_socket_connection (&data->client_fd);
+    data->connection = connection_new (server_socket,
                                        CLIENT_ID,
                                        data->handle_map);
     data->session_entry = session_entry_new (data->connection, TEST_HANDLE);

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -97,6 +97,7 @@ tpm2_command_setup_base (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
@@ -104,8 +105,10 @@ tpm2_command_setup_base (void **state)
     data->buffer_size = TPM_RESPONSE_HEADER_SIZE + sizeof (TPM_HANDLE) * 3;
     data->buffer = calloc (1, data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     *state = data;
     return 0;
 }
@@ -168,13 +171,16 @@ tpm2_command_setup_two_handles_not_three (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     *state = data;
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     /* */
     data->buffer_size = sizeof (two_handles_not_three);
     data->buffer = calloc (1, data->buffer_size);
@@ -197,6 +203,7 @@ tpm2_command_setup_with_auths (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
     TPMA_CC attributes = {
         .val = 2 << 25,
@@ -208,8 +215,10 @@ tpm2_command_setup_with_auths (void **state)
     data->buffer = calloc (1, data->buffer_size);
     memcpy (data->buffer, cmd_with_auths, sizeof (cmd_with_auths));
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     data->command = tpm2_command_new (data->connection,
                                       data->buffer,
                                       data->buffer_size,
@@ -223,6 +232,7 @@ tpm2_command_setup_flush_context_no_handle (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
     TPMA_CC attributes = {
         .val = 2 << 25,
@@ -236,8 +246,10 @@ tpm2_command_setup_flush_context_no_handle (void **state)
             cmd_buf_context_flush_no_handle,
             data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     data->command = tpm2_command_new (data->connection,
                                       data->buffer,
                                       data->buffer_size,
@@ -591,13 +603,16 @@ tpm2_command_setup_get_cap_no_cap (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     *state = data;
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
 
     data->buffer_size = sizeof (get_cap_no_cap);
     data->buffer = calloc (1, data->buffer_size);

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -33,6 +33,7 @@
 
 #include "tpm2-header.h"
 #include "tpm2-response.h"
+#include "util.h"
 
 #define HANDLE_TEST 0xdeadbeef
 #define HANDLE_TYPE 0xde
@@ -53,14 +54,17 @@ tpm2_response_setup_base (void **state)
     test_data_t *data   = NULL;
     gint         client_fd;
     HandleMap   *handle_map;
+    GSocket     *server_socket;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold a TPM2 header and a handle */
     data->buffer_size = TPM_RESPONSE_HEADER_SIZE + sizeof (TPM_HANDLE);
     data->buffer   = calloc (1, data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection  = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection  = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
 
     *state = data;
     return 0;
@@ -252,13 +256,16 @@ tpm2_response_new_rc_setup (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
+    GSocket     *server_socket;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold a TPM2 header */
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    data->connection  = connection_new (&client_fd, 0, handle_map);
+    server_socket = create_socket_connection (&client_fd);
+    data->connection  = connection_new (server_socket, 0, handle_map);
     g_object_unref (handle_map);
+    g_object_unref (server_socket);
     data->response = tpm2_response_new_rc (data->connection, TPM_RC_BINDING);
 
     *state = data;

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -25,6 +25,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -199,6 +200,19 @@ read_data_teardown (void **state)
     }
     return 0;
 }
+/*
+ */
+static void
+create_socket_pair_success_test (void **state)
+{
+    int ret, client_fd, server_fd;
+
+    ret = create_socket_pair (&client_fd, &server_fd, O_CLOEXEC);
+    if (ret == -1)
+        g_error ("create_pipe_pair failed: %s", strerror (errno));
+    close (client_fd);
+}
+
 /*
  * Simple call to read wrapper function. Returns exactly what we ask for.
  * We check to be sure return value is 0, the index variable is updated
@@ -669,6 +683,7 @@ main (gint    argc,
         cmocka_unit_test (write_in_three),
         cmocka_unit_test (write_error),
         cmocka_unit_test (write_zero),
+        cmocka_unit_test (create_socket_pair_success_test),
         /* read_data tests */
         cmocka_unit_test_setup_teardown (read_data_success_test,
                                          read_data_setup,


### PR DESCRIPTION
By creating the socket pair in the _new function we tighly couple the
Connection object to the IPC mechanism. Moving this out to the place
where we have the rest of the DBus code breaks this coupling.

The majority of this commit are fixups in the unit tests.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>