### PR TITLE
Command: Replace use of GSocket with GIOStream.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -327,7 +327,7 @@ test_command_attrs_unit_SOURCES  = test/command-attrs_unit.c
 
 test_command_source_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_command_source_unit_LDADD   = $(CMOCKA_LIBS) $(GLIB_LIBS) $(SAPI_LIBS) $(PTHREAD_LIBS) $(GOBJECT_LIBS) $(libutil)
-test_command_source_unit_LDFLAGS = -Wl,--wrap=g_source_set_callback,--wrap=connection_manager_lookup_socket,--wrap=connection_manager_remove,--wrap=sink_enqueue,--wrap=read_tpm_buffer_alloc,--wrap=command_attrs_from_cc
+test_command_source_unit_LDFLAGS = -Wl,--wrap=g_source_set_callback,--wrap=connection_manager_lookup_istream,--wrap=connection_manager_remove,--wrap=sink_enqueue,--wrap=read_tpm_buffer_alloc,--wrap=command_attrs_from_cc
 test_command_source_unit_SOURCES = test/command-source_unit.c
 
 test_handle_map_entry_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
@@ -366,7 +366,7 @@ test_tpm2_response_unit_SOURCES = test/tpm2-response_unit.c
 
 test_util_unit_CFLAGS  = $(UNIT_AM_CFLAGS)
 test_util_unit_LDADD  = $(CMOCKA_LIBS) $(GLIB_LIBS) $(libutil)
-test_util_unit_LDFLAGS = -Wl,--wrap=g_socket_receive,--wrap=g_socket_send
+test_util_unit_LDFLAGS = -Wl,--wrap=g_input_stream_read,--wrap=g_output_stream_write
 test_util_unit_SOURCES = test/util_unit.c
 
 test_message_queue_unit_CFLAGS  = $(UNIT_AM_CFLAGS)

--- a/src/command-source.h
+++ b/src/command-source.h
@@ -53,7 +53,7 @@ typedef struct _CommandSource {
     CommandAttrs      *command_attrs;
     GMainContext      *main_context;
     GMainLoop         *main_loop;
-    GHashTable        *socket_to_source_data_map;
+    GHashTable        *istream_to_source_data_map;
     Sink              *sink;
 } CommandSource;
 
@@ -74,8 +74,7 @@ gint            command_source_on_new_connection (ConnectionManager  *connection
  * The following are private functions. They are exposed here for unit
  * testing. Do not call these from anywhere else.
  */
-gboolean        command_source_on_io_ready       (GSocket            *socket,
-                                                  GIOCondition        condition,
+gboolean        command_source_on_input_ready    (GInputStream       *socket,
                                                   gpointer            user_data);
 /*
  * Instances of this structure are used to track GSources and their

--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -116,7 +116,7 @@ connection_manager_new (guint max_connections)
      * set this for one of the hash tables because we only want to free
      * each Connection object once.
      */
-    mgr->connection_from_socket_table =
+    mgr->connection_from_istream_table =
         g_hash_table_new_full (g_direct_hash,
                                g_direct_equal,
                                NULL,
@@ -144,7 +144,7 @@ connection_manager_finalize (GObject *obj)
     if (ret != 0)
         g_error ("Error locking connection_manager mutex: %s",
                  strerror (errno));
-    g_hash_table_unref (manager->connection_from_socket_table);
+    g_hash_table_unref (manager->connection_from_istream_table);
     g_hash_table_unref (manager->connection_from_id_table);
     ret = pthread_mutex_unlock (&manager->mutex);
     if (ret != 0)
@@ -235,8 +235,8 @@ connection_manager_insert (ConnectionManager    *manager,
      * count to be decreased (see g_hash_table_new_full).
      */
     g_object_ref (connection);
-    g_hash_table_insert (manager->connection_from_socket_table,
-                         connection_key_socket (connection),
+    g_hash_table_insert (manager->connection_from_istream_table,
+                         connection_key_istream (connection),
                          connection);
     g_hash_table_insert (manager->connection_from_id_table,
                          connection_key_id (connection),
@@ -260,14 +260,14 @@ connection_manager_insert (ConnectionManager    *manager,
  * by the caller.
  */
 Connection*
-connection_manager_lookup_socket (ConnectionManager *manager,
-                                  GSocket           *socket)
+connection_manager_lookup_istream (ConnectionManager *manager,
+                                   GInputStream      *istream)
 {
     Connection *connection;
 
     pthread_mutex_lock (&manager->mutex);
-    connection = g_hash_table_lookup (manager->connection_from_socket_table,
-                                      socket);
+    connection = g_hash_table_lookup (manager->connection_from_istream_table,
+                                      istream);
     if (connection != NULL) {
         g_object_ref (connection);
     } else {
@@ -321,19 +321,19 @@ connection_manager_remove (ConnectionManager   *manager,
     g_debug ("connection_manager 0x%" PRIxPTR " removing Connection 0x%" PRIxPTR,
              (uintptr_t)manager, (uintptr_t)connection);
     pthread_mutex_lock (&manager->mutex);
-    ret = g_hash_table_remove (manager->connection_from_socket_table,
-                               connection_key_socket (connection));
+    ret = g_hash_table_remove (manager->connection_from_istream_table,
+                               connection_key_istream (connection));
     if (ret != TRUE)
         g_error ("failed to remove Connection 0x%" PRIxPTR " from g_hash_table "
                  "0x%" PRIxPTR "using key 0x%" PRIxPTR, (uintptr_t)connection,
-                 (uintptr_t)manager->connection_from_socket_table,
-                 (uintptr_t)connection_key_socket (connection));
+                 (uintptr_t)manager->connection_from_istream_table,
+                 (uintptr_t)connection_key_istream (connection));
     ret = g_hash_table_remove (manager->connection_from_id_table,
                                connection_key_id (connection));
     if (ret != TRUE)
         g_error ("failed to remove Connection 0x%" PRIxPTR " from g_hash_table "
                  "0x%" PRIxPTR " using key %" PRIxPTR, (uintptr_t)connection,
-                 (uintptr_t)manager->connection_from_socket_table,
+                 (uintptr_t)manager->connection_from_istream_table,
                  (uintptr_t)connection_key_id (connection));
     pthread_mutex_unlock (&manager->mutex);
     g_signal_emit (manager,
@@ -348,7 +348,7 @@ connection_manager_remove (ConnectionManager   *manager,
 guint
 connection_manager_size (ConnectionManager   *manager)
 {
-    return g_hash_table_size (manager->connection_from_socket_table);
+    return g_hash_table_size (manager->connection_from_istream_table);
 }
 
 gboolean
@@ -356,7 +356,7 @@ connection_manager_is_full (ConnectionManager *manager)
 {
     guint table_size;
 
-    table_size = g_hash_table_size (manager->connection_from_socket_table);
+    table_size = g_hash_table_size (manager->connection_from_istream_table);
     if (table_size < manager->max_connections) {
         return FALSE;
     } else {

--- a/src/connection-manager.h
+++ b/src/connection-manager.h
@@ -44,7 +44,7 @@ typedef struct _ConnectionManagerClass {
 typedef struct _ConnectionManager {
     GObject           parent_instance;
     pthread_mutex_t   mutex;
-    GHashTable       *connection_from_socket_table;
+    GHashTable       *connection_from_istream_table;
     GHashTable       *connection_from_id_table;
     guint             max_connections;
 } ConnectionManager;
@@ -67,8 +67,8 @@ gint           connection_manager_insert      (ConnectionManager  *manager,
                                                Connection         *connection);
 gint           connection_manager_remove      (ConnectionManager  *manager,
                                                Connection         *connection);
-Connection*    connection_manager_lookup_socket (ConnectionManager  *manager,
-                                                 GSocket            *socket);
+Connection*    connection_manager_lookup_istream (ConnectionManager  *manager,
+                                                  GInputStream       *istream);
 Connection*    connection_manager_lookup_id   (ConnectionManager  *manager,
                                                gint64              id_in);
 gboolean       connection_manager_contains_id (ConnectionManager  *manager,

--- a/src/connection.h
+++ b/src/connection.h
@@ -41,7 +41,7 @@ typedef struct _ConnectionClass {
 
 typedef struct _Connection {
     GObject             parent_instance;
-    GSocket            *socket;
+    GIOStream          *iostream;
     guint64             id;
     HandleMap          *transient_handle_map;
 } Connection;
@@ -54,11 +54,11 @@ typedef struct _Connection {
 #define CONNECTION_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj),  TYPE_CONNECTION, ConnectionClass))
 
 GType            connection_get_type     (void);
-Connection*      connection_new          (GSocket         *socket,
+Connection*      connection_new          (GIOStream       *iostream,
                                           guint64          id,
                                           HandleMap       *transient_handle_map);
-gpointer         connection_key_socket   (Connection      *session);
+gpointer         connection_key_istream  (Connection      *session);
 gpointer         connection_key_id       (Connection      *session);
-GSocket*         connection_get_gsocket  (Connection      *connection);
+GIOStream*       connection_get_iostream (Connection      *connection);
 HandleMap*       connection_get_trans_map(Connection      *session);
 #endif /* CONNECTION_H */

--- a/src/response-sink.c
+++ b/src/response-sink.c
@@ -207,17 +207,18 @@ response_sink_process_response (Tpm2Response *response)
     guint32      size    = tpm2_response_get_size (response);
     guint8      *buffer  = tpm2_response_get_buffer (response);
     Connection  *connection = tpm2_response_get_connection (response);
-    GSocket     *socket  = connection_get_gsocket (connection);
+    GIOStream   *iostream = connection_get_iostream (connection);
+    GOutputStream *ostream = g_io_stream_get_output_stream (iostream);
 
     g_debug ("response_sink_thread got response: 0x%" PRIxPTR " size %d",
              (uintptr_t)response, size);
     g_debug ("  writing 0x%x bytes", size);
     g_debug_bytes (buffer, size, 16, 4);
-    written = write_all (socket, buffer, size);
+    written = write_all (ostream, buffer, size);
     if (written <= 0)
-        g_warning ("write failed (%zu) on socket 0x%" PRIxPTR " for connection"
+        g_warning ("write failed (%zu) on ostream 0x%" PRIxPTR " for connection"
                    "  0x%" PRIxPTR ": %s",
-                   written, (uintptr_t)socket, (uintptr_t)connection,
+                   written, (uintptr_t)ostream, (uintptr_t)connection,
                    strerror (errno));
     g_object_unref (connection);
 

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -256,7 +256,7 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
     HandleMap   *handle_map = NULL;
     Connection *connection = NULL;
     gint client_fd = 0, ret = 0;
-    GSocket *server_socket;
+    GIOStream *server_iostream;
     GVariant *response_variants[2], *response_tuple;
     GUnixFDList *fd_list = NULL;
     guint64 id = 0, id_pid_mix = 0;
@@ -294,10 +294,10 @@ on_handle_create_connection (TctiTabrmd            *skeleton,
     handle_map = handle_map_new (TPM_HT_TRANSIENT, data->options.max_transient_objects);
     if (handle_map == NULL)
         g_error ("Failed to allocate new HandleMap");
-    server_socket = create_socket_connection (&client_fd);
-    connection = connection_new (server_socket, id_pid_mix, handle_map);
+    server_iostream = create_connection_iostream (&client_fd);
+    connection = connection_new (server_iostream, id_pid_mix, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (server_iostream);
     if (connection == NULL)
         g_error ("Failed to allocate new connection.");
     g_debug ("Created connection with fd: %d and id: 0x%" PRIx64,

--- a/src/tcti-tabrmd-priv.h
+++ b/src/tcti-tabrmd-priv.h
@@ -40,14 +40,28 @@
 
 #define TSS2_TCTI_TABRMD_ID(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->id
-#define TSS2_TCTI_TABRMD_SOCKET(context) \
-    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->socket
+#define TSS2_TCTI_TABRMD_IOSTREAM(context) \
+    G_IO_STREAM (TSS2_TCTI_TABRMD_SOCK_CONNECT (context))
 #define TSS2_TCTI_TABRMD_PROXY(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->proxy
 #define TSS2_TCTI_TABRMD_HEADER(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->header
 #define TSS2_TCTI_TABRMD_STATE(context) \
     ((TSS2_TCTI_TABRMD_CONTEXT*)context)->state
+
+/*
+ * Macros for accessing the internals of the I/O stream. These are helpers
+ * for getting at the underlying GSocket and raw fds that we need to
+ * implement polling etc.
+ */
+#define TSS2_TCTI_TABRMD_ISTREAM(context) \
+    g_io_stream_get_input_stream (TSS2_TCTI_TABRMD_IOSTREAM(context))
+#define TSS2_TCTI_TABRMD_SOCK_CONNECT(context) \
+    ((TSS2_TCTI_TABRMD_CONTEXT*)context)->sock_connect
+#define TSS2_TCTI_TABRMD_SOCKET(context) \
+    g_socket_connection_get_socket (TSS2_TCTI_TABRMD_SOCK_CONNECT (context))
+#define TSS2_TCTI_TABRMD_FD(context) \
+    g_socket_get_fd (TSS2_TCTI_TABRMD_SOCKET (context))
 
 /*
  * The elements in this enumeration represent the possible states that the
@@ -90,7 +104,7 @@ typedef enum {
 typedef struct {
     TSS2_TCTI_CONTEXT_COMMON_V1    common;
     guint64                        id;
-    GSocket                       *socket;
+    GSocketConnection             *sock_connect;
     TctiTabrmd                    *proxy;
     tpm_header_t                   header;
     tcti_tabrmd_state_t            state;

--- a/src/util.h
+++ b/src/util.h
@@ -54,24 +54,24 @@
 #define TPMA_CC_RES(attrs)         (attrs.val & 0xc0000000)
 */
 
-ssize_t     write_all                       (GSocket          *socket,
+ssize_t     write_all                       (GOutputStream    *ostream,
                                              const uint8_t    *buf,
                                              const size_t      size);
-int         read_data                       (GSocket          *socket,
+int         read_data                       (GInputStream     *istream,
                                              size_t           *index,
                                              uint8_t          *buf,
                                              size_t            count);
-int         read_tpm_buffer                 (GSocket          *socket,
+int         read_tpm_buffer                 (GInputStream     *istream,
                                              size_t           *index,
                                              uint8_t          *buf,
                                              size_t            buf_size);
-uint8_t*    read_tpm_buffer_alloc           (GSocket          *socket,
+uint8_t*    read_tpm_buffer_alloc           (GInputStream     *istream,
                                              size_t           *buf_size);
 void        g_debug_bytes                   (uint8_t const    *byte_array,
                                              size_t            array_size,
                                              size_t            width,
                                              size_t            indent);
-GSocket*    create_socket_connection        (int              *client_fd);
+GIOStream*  create_connection_iostream      (int              *client_fd);
 int         create_socket_pair              (int              *fd_a,
                                              int              *fd_b,
                                              int               flags);

--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -174,17 +174,17 @@ access_broker_setup_with_command (void **state)
     guint8 *buffer;
     size_t  buffer_size;
     HandleMap *handle_map;
-    GSocket   *server_socket;
+    GIOStream *iostream;
 
     access_broker_setup_with_init (state);
     data = (test_data_t*)*state;
     buffer_size = TPM_HEADER_SIZE;
     buffer = calloc (1, buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     data->command = tpm2_command_new (data->connection,
                                       buffer,
                                       buffer_size,

--- a/test/connection-manager_unit.c
+++ b/test/connection-manager_unit.c
@@ -80,13 +80,13 @@ connection_manager_insert_test (void **state)
     Connection *connection = NULL;
     HandleMap   *handle_map = NULL;
     gint ret, client_fd;
-    GSocket *server_socket;
+    GIOStream *iostream;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    connection = connection_new (server_socket, 5, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    connection = connection_new (iostream, 5, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, 0);
 }
@@ -98,17 +98,17 @@ connection_manager_lookup_fd_test (void **state)
     Connection *connection = NULL, *connection_lookup = NULL;
     HandleMap   *handle_map = NULL;
     gint ret, client_fd;
-    GSocket *server_socket;
+    GIOStream *iostream;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    connection = connection_new (server_socket, 5, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    connection = connection_new (iostream, 5, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
-    connection_lookup = connection_manager_lookup_socket (manager,
-                                                          connection_key_socket (connection));
+    connection_lookup = connection_manager_lookup_istream (manager,
+                                                           connection_key_istream (connection));
     assert_int_equal (connection, connection_lookup);
     g_object_unref (connection_lookup);
 }
@@ -119,14 +119,14 @@ connection_manager_lookup_id_test (void **state)
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL, *connection_lookup = NULL;
     HandleMap   *handle_map = NULL;
-    GSocket     *server_socket;
+    GIOStream *iostream;
     gint ret, client_fd;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    connection = connection_new (server_socket, 5, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    connection = connection_new (iostream, 5, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     ret = connection_manager_insert (manager, connection);
     assert_int_equal (ret, TSS2_RC_SUCCESS);
     connection_lookup = connection_manager_lookup_id (manager, *(int*)connection_key_id (connection));
@@ -138,16 +138,16 @@ connection_manager_remove_test (void **state)
 {
     ConnectionManager *manager = CONNECTION_MANAGER (*state);
     Connection *connection = NULL;
-    GSocket     *server_socket;
+    GIOStream *iostream;
     HandleMap   *handle_map = NULL;
     gint ret_int, client_fd;
     gboolean ret_bool;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    connection = connection_new (server_socket, 5, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    connection = connection_new (iostream, 5, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     ret_int = connection_manager_insert (manager, connection);
     assert_int_equal (ret_int, 0);
     ret_bool = connection_manager_remove (manager, connection);

--- a/test/connection_unit.c
+++ b/test/connection_unit.c
@@ -28,6 +28,8 @@
 
 #include <errno.h>
 #include <error.h>
+#include <gio/gunixinputstream.h>
+#include <gio/gunixoutputstream.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,22 +44,28 @@
 
 typedef struct connection_test_data {
     Connection *connection;
-    GSocket    *client_socket;
+    GIOStream  *client_iostream;
 } connection_test_data_t;
-
+/*
+ * Data goes in the iostream_in, and out the iostream_out.
+ */
 static int
-write_read (GSocket    *socket_in,
-            GSocket    *socket_out,
+write_read (GIOStream  *iostream_in,
+            GIOStream  *iostream_out,
             const char *buf,
             size_t      length)
 {
     char out_buf[256] = { 0 };
     ssize_t ret;
+    GInputStream *istream;
+    GOutputStream *ostream;
 
-    ret = g_socket_send (socket_in, buf, length, NULL, NULL);
+    ostream = g_io_stream_get_output_stream (iostream_in);
+    ret = g_output_stream_write (ostream, buf, length, NULL, NULL);
     if (ret != length)
         g_error ("error writing to fds[1]: %s", strerror (errno));
-    ret = g_socket_receive (socket_out, out_buf, length, NULL, NULL);
+    istream = g_io_stream_get_input_stream (iostream_out);
+    ret = g_input_stream_read (istream, out_buf, length, NULL, NULL);
     if (ret != length)
         g_error ("error reading from fds[0]: %s", strerror (errno));
 
@@ -70,13 +78,13 @@ connection_allocate_test (void **state)
     HandleMap   *handle_map = NULL;
     Connection *connection = NULL;
     gint client_fd;
-    GSocket *server_socket;
+    GIOStream *iostream;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     assert_non_null (connection);
     assert_true (client_fd >= 0);
     g_object_unref (connection);
@@ -88,17 +96,21 @@ connection_setup (void **state)
     connection_test_data_t *data = NULL;
     HandleMap *handle_map = NULL;
     int client_fd;
-    GSocket *server_socket;
+    GIOStream *iostream;
+    GSocket *socket;
 
     data = calloc (1, sizeof (connection_test_data_t));
     assert_non_null (data);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
-    data->client_socket = g_socket_new_from_fd (client_fd, NULL);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
+    g_object_unref (iostream);
+    socket = g_socket_new_from_fd (client_fd, NULL);
+    data->client_iostream =
+        G_IO_STREAM (g_socket_connection_factory_create_connection (socket));
+    g_object_unref (socket);
     assert_non_null (data->connection);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
     *state = data;
     return 0;
 }
@@ -109,7 +121,7 @@ connection_teardown (void **state)
     connection_test_data_t *data = (connection_test_data_t*)*state;
 
     g_object_unref (data->connection);
-    g_object_unref (data->client_socket);
+    g_object_unref (data->client_iostream);
     free (data);
     return 0;
 }
@@ -121,8 +133,9 @@ connection_key_socket_test (void **state)
     Connection *connection = CONNECTION (data->connection);
     gpointer *key = NULL;
 
-    key = connection_key_socket (connection);
-    assert_ptr_equal (connection->socket, key);
+    key = connection_key_istream (connection);
+    assert_ptr_equal (g_io_stream_get_input_stream (connection->iostream),
+                                                    key);
 }
 
 static void
@@ -146,7 +159,7 @@ connection_client_to_server_test (void ** state)
     connection_test_data_t *data = (connection_test_data_t*)*state;
     gint ret = 0;
 
-    ret = write_read (data->connection->socket, data->client_socket, "test", strlen ("test"));
+    ret = write_read (data->connection->iostream, data->client_iostream, "test", strlen ("test"));
     if (ret == -1)
         g_print ("write_read failed: %d\n", ret);
     assert_int_equal (ret, strlen ("test"));
@@ -161,8 +174,8 @@ connection_server_to_client_test (void **state)
     connection_test_data_t *data = (connection_test_data_t*)*state;
     gint ret = 0;
 
-    ret = write_read (data->client_socket,
-                      data->connection->socket,
+    ret = write_read (data->client_iostream,
+                      data->connection->iostream,
                       "test",
                       strlen ("test"));
     if (ret == -1)

--- a/test/message-queue_unit.c
+++ b/test/message-queue_unit.c
@@ -77,17 +77,17 @@ message_queue_enqueue_dequeue_test (void **state)
     Connection  *obj_in, *obj_out;
     HandleMap    *handle_map;
     gint          client_fd;
-    GSocket      *server_socket;
+    GIOStream *iostream;
 
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    obj_in = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    obj_in = connection_new (iostream, 0, handle_map);
     message_queue_enqueue (queue, G_OBJECT (obj_in));
     obj_out = CONNECTION (message_queue_dequeue (queue));
     /* ptr != int but they're the same size usually? */
     assert_int_equal (obj_in, obj_out);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
 }
 
 static void
@@ -98,21 +98,21 @@ message_queue_dequeue_order_test (void **state)
     MessageQueue *queue = data->queue;
     Connection *obj_0, *obj_1, *obj_2, *obj_tmp;
     gint client_fd;
-    GSocket *server_socket;
+    GIOStream *iostream;
 
     map_0 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     map_1 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     map_2 = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
 
-    server_socket = create_socket_connection (&client_fd);
-    obj_0 = connection_new (server_socket, 0, map_0);
-    g_object_unref (server_socket);
-    server_socket = create_socket_connection (&client_fd);
-    obj_1 = connection_new (server_socket, 0, map_1);
-    g_object_unref (server_socket);
-    server_socket = create_socket_connection (&client_fd);
-    obj_2 = connection_new (server_socket, 0, map_2);
-    g_object_unref (server_socket);
+    iostream = create_connection_iostream (&client_fd);
+    obj_0 = connection_new (iostream, 0, map_0);
+    g_object_unref (iostream);
+    iostream = create_connection_iostream (&client_fd);
+    obj_1 = connection_new (iostream, 0, map_1);
+    g_object_unref (iostream);
+    iostream = create_connection_iostream (&client_fd);
+    obj_2 = connection_new (iostream, 0, map_2);
+    g_object_unref (iostream);
 
     message_queue_enqueue (queue, G_OBJECT (obj_0));
     message_queue_enqueue (queue, G_OBJECT (obj_1));

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -120,7 +120,7 @@ static int
 resource_manager_setup (void **state)
 {
     test_data_t *data;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
     TSS2_RC rc;
 
@@ -132,10 +132,10 @@ resource_manager_setup (void **state)
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
     data->access_broker = access_broker_new (TCTI (data->tcti_echo));
     data->resource_manager = resource_manager_new (data->access_broker);
-    server_socket = create_socket_connection (&data->client_fd);
-    data->connection = connection_new (server_socket, 10, handle_map);
+    iostream = create_connection_iostream (&data->client_fd);
+    data->connection = connection_new (iostream, 10, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
 
     *state = data;
     return 0;

--- a/test/session-entry_unit.c
+++ b/test/session-entry_unit.c
@@ -49,15 +49,16 @@ static int
 session_entry_setup (void **state)
 {
     test_data_t *data   = NULL;
-    GSocket *server_socket;
+    GIOStream *iostream;
 
     data = calloc (1, sizeof (test_data_t));
     data->handle_map = handle_map_new (TPM_HT_TRANSIENT, 100);
-    server_socket = create_socket_connection (&data->client_fd);
-    data->connection = connection_new (server_socket,
+    iostream = create_connection_iostream (&data->client_fd);
+    data->connection = connection_new (iostream,
                                        CLIENT_ID,
                                        data->handle_map);
     data->session_entry = session_entry_new (data->connection, TEST_HANDLE);
+    g_object_unref (iostream);
 
     *state = data;
     return 0;

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -97,7 +97,7 @@ tpm2_command_setup_base (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
@@ -105,10 +105,10 @@ tpm2_command_setup_base (void **state)
     data->buffer_size = TPM_RESPONSE_HEADER_SIZE + sizeof (TPM_HANDLE) * 3;
     data->buffer = calloc (1, data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     *state = data;
     return 0;
 }
@@ -171,16 +171,16 @@ tpm2_command_setup_two_handles_not_three (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     *state = data;
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     /* */
     data->buffer_size = sizeof (two_handles_not_three);
     data->buffer = calloc (1, data->buffer_size);
@@ -203,7 +203,7 @@ tpm2_command_setup_with_auths (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
     TPMA_CC attributes = {
         .val = 2 << 25,
@@ -215,10 +215,10 @@ tpm2_command_setup_with_auths (void **state)
     data->buffer = calloc (1, data->buffer_size);
     memcpy (data->buffer, cmd_with_auths, sizeof (cmd_with_auths));
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     data->command = tpm2_command_new (data->connection,
                                       data->buffer,
                                       data->buffer_size,
@@ -232,7 +232,7 @@ tpm2_command_setup_flush_context_no_handle (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
     TPMA_CC attributes = {
         .val = 2 << 25,
@@ -246,10 +246,10 @@ tpm2_command_setup_flush_context_no_handle (void **state)
             cmd_buf_context_flush_no_handle,
             data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     data->command = tpm2_command_new (data->connection,
                                       data->buffer,
                                       data->buffer_size,
@@ -603,16 +603,16 @@ tpm2_command_setup_get_cap_no_cap (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     *state = data;
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
 
     data->buffer_size = sizeof (get_cap_no_cap);
     data->buffer = calloc (1, data->buffer_size);

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -54,17 +54,17 @@ tpm2_response_setup_base (void **state)
     test_data_t *data   = NULL;
     gint         client_fd;
     HandleMap   *handle_map;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold a TPM2 header and a handle */
     data->buffer_size = TPM_RESPONSE_HEADER_SIZE + sizeof (TPM_HANDLE);
     data->buffer   = calloc (1, data->buffer_size);
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection  = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection  = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
 
     *state = data;
     return 0;
@@ -256,16 +256,16 @@ tpm2_response_new_rc_setup (void **state)
 {
     test_data_t *data   = NULL;
     gint         client_fd;
-    GSocket     *server_socket;
+    GIOStream   *iostream;
     HandleMap   *handle_map;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold a TPM2 header */
     handle_map = handle_map_new (TPM_HT_TRANSIENT, MAX_ENTRIES_DEFAULT);
-    server_socket = create_socket_connection (&client_fd);
-    data->connection  = connection_new (server_socket, 0, handle_map);
+    iostream = create_connection_iostream (&client_fd);
+    data->connection  = connection_new (iostream, 0, handle_map);
     g_object_unref (handle_map);
-    g_object_unref (server_socket);
+    g_object_unref (iostream);
     data->response = tpm2_response_new_rc (data->connection, TPM_RC_BINDING);
 
     *state = data;

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -1077,7 +1077,7 @@ tcti_tabrmd_get_poll_handles_handles_test (void **state)
     rc = tss2_tcti_get_poll_handles (data->context, handles, &num_handles);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (1, num_handles);
-    fd = g_socket_get_fd (TSS2_TCTI_TABRMD_SOCKET (data->context));
+    fd = TSS2_TCTI_TABRMD_FD (data->context);
     assert_int_equal (handles [0].fd, fd);
 }
 /*


### PR DESCRIPTION
This change touches a number of other objects. The CommandSource and
ResponseSink objects now use GInputStream and GOutputStreams
respectively. The ConnectionManager object is also updated to allow
lookups from the CommandSource using the GInputStream associated with
the Connection.

The util module is also updated to use GInputStream and GOutputStream
objects in place of the GSockets.

Finally all of the unit tests that handle Connection objects or do I/O
using the util functions had to be updated.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>