### PR TITLE
IpcFrontendDbus: Give better warning when name can't be acquired.

### DIFF
--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -115,7 +115,9 @@ ipc_frontend_dbus_get_property (GObject    *object,
 }
 static void
 ipc_frontend_dbus_init (IpcFrontendDbus *self)
-{ /* n00p */ }
+{
+    self->dbus_name_acquired = FALSE;
+}
 /*
  * Dispose method where where we free up references to other objects.
  */
@@ -607,6 +609,7 @@ on_name_acquired (GDBusConnection *connection,
         &error);
     if (ret == FALSE)
         g_warning ("failed to export interface: %s", error->message);
+    self->dbus_name_acquired = TRUE;
 }
 /*
  * This is a signal handler of type GBusNameLostCallback. It is
@@ -619,8 +622,17 @@ on_name_lost (GDBusConnection *connection,
               const gchar     *name,
               gpointer         user_data)
 {
-    g_info ("on_name_lost: %s", name);
+    g_debug ("%s: %s", __func__, name);
     IpcFrontend *ipc_frontend = IPC_FRONTEND (user_data);
+    IpcFrontendDbus *self = IPC_FRONTEND_DBUS (user_data);
+
+    if (self->dbus_name_acquired == FALSE) {
+        g_critical ("Failed to acquire DBus name %s. UID %d must be "
+                    "allowed to \"own\" this name. Check DBus config.",
+                    name, getuid ());
+    } else {
+        self->dbus_name_acquired = FALSE;
+    }
 
     ipc_frontend_disconnected_invoke (ipc_frontend);
 }

--- a/src/ipc-frontend-dbus.h
+++ b/src/ipc-frontend-dbus.h
@@ -51,6 +51,7 @@ typedef struct _IpcFrontendDbus
     gchar             *bus_name;
     GBusType           bus_type;
     /* private data */
+    gboolean           dbus_name_acquired;
     guint              dbus_name_owner_id;
     guint              max_transient_objects;
     ConnectionManager *connection_manager;


### PR DESCRIPTION
The event triggered when the name is lost doesn't provide a reason
as to why. As a result the warning displayed when this happened left
a lot of users guessing as to why. According to the GIO docs, if we
try to acquire a name on DBus and get the name lost event without
first getting the name acquired event then the we have a problem with
permissions in the DBus config.

https://developer.gnome.org/gio/stable/gio-Owning-Bus-Names.html#g-bus-own-name

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>