### PR TITLE
IpcFrontendDbus: Add missing 'break' in property setter.

### DIFF
--- a/src/ipc-frontend-dbus.c
+++ b/src/ipc-frontend-dbus.c
@@ -72,6 +72,7 @@ ipc_frontend_dbus_set_property (GObject      *object,
     case PROP_CONNECTION_MANAGER:
         self->connection_manager = g_value_get_object (value);
         g_object_ref (self->connection_manager);
+        break;
     case PROP_MAX_TRANS:
         self->max_transient_objects = g_value_get_uint (value);
         break;


### PR DESCRIPTION
This keeps the property setter from falling through and causing GLib
to barf up a CRITICAL error executing the second 'case' statement.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>