### PR TITLE
SELinux: Add policy module for tabrmd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .deps/
 .dirstamp
 .libs/
+tmp/
 *.la
 *.lo
 *.log
 *.o
+*.pp
 *.swp
 *.trs
 Makefile

--- a/contrib/tabrmd.fc
+++ b/contrib/tabrmd.fc
@@ -1,0 +1,2 @@
+/usr/sbin/tpm2-abrmd	--	gen_context(system_u:object_r:tabrmd_exec_t,s0)
+/usr/local/sbin/tpm2-abrmd	--	gen_context(system_u:object_r:tabrmd_exec_t,s0)

--- a/contrib/tabrmd.if
+++ b/contrib/tabrmd.if
@@ -1,0 +1,1 @@
+## <summary></summary>

--- a/contrib/tabrmd.te
+++ b/contrib/tabrmd.te
@@ -1,0 +1,26 @@
+policy_module(tabrmd, 0.0.1)
+
+########################################
+#
+# Declarations
+#
+
+type tabrmd_t;
+type tabrmd_exec_t;
+init_daemon_domain(tabrmd_t, tabrmd_exec_t)
+
+allow tabrmd_t self:unix_dgram_socket { create_socket_perms };
+
+dev_rw_tpm(tabrmd_t)
+logging_send_syslog_msg(tabrmd_t)
+
+optional_policy(`
+    dbus_system_domain(tabrmd_t, tabrmd_exec_t)
+')
+
+# This next bit doesn't belong here. It should be exposed through an
+# interface likely from the dbus policy module.
+gen_require(`
+    type system_dbusd_t;
+')
+allow system_dbusd_t tabrmd_t:unix_stream_socket { read write };


### PR DESCRIPTION
This is necessary because the default Fedora policy for the
unconfined_service_t type (the default context for a service w/o a
private type) doesn't allow the system_dbusd_t type to read / write
from it's stream sockets. Pipes were fine, but not stream sockets.

The policy module added here is a work around. The dbus policy module
doesn't have an interface to allow this type of access and so I've
hacked up this module to allow the operation. The form of the module
isn't right though and it's likely that we'll need to add such an
interface to the dbus module. This will require some collaboration /
vetting with the upstream refpolicy maintainers though.

The build system has not been updated to support building the policy
module so those on Fedora will have to build it manually. This isn't
hard though:
1) sudo dnf install selinux-policy-devel
2) pushd contrib && make -f /usr/share/selinux/devel/Makefile tabrmd.pp
3) sudo semodule -i tabrmd.pp
4) sudo restorecon /path/to/tpm2-abrmd
5) popd

At this point the new module should be loaded. You can verify this with
the semodule command. Additionally you should check to be sure the lable
on the label on the tpm2-abrmd binary is the `tabrmd_exec_t` type. Then
just stop & restart the daemon. It should now be running in the tabrmd_t
domain. You can verify this with the `ps` command.

`ps auxZ | grep tpm2-abrmd` should display something like:
system_u:system_r:tabrmd_t:s0   tss       6678  0.5  0.0 587400  4112 ?        Ssl  14:47   0:00 /usr/local/sbin/tpm2-abrmd

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>