### PR TITLE
Add --flush-all command line option.

### DIFF
--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -28,6 +28,9 @@ Cause the daemon to fail on startup when the TPM is found to already have
 transient objects loaded. This is intended as a safe-guard to keep the
 daemon from stomping on the TPM state setup by another process.
 .TP
+\fB\-f,\ \-\-flush-all\fR
+Flush all objects and sessions when daemon is started.
+.TP
 \fB\-l,\ \-\-logger\fR
 Direct logging output to named logging target. Supported targets are
 \fBstdout\fR and \fBsyslog\fR. If the logger option is not specified the

--- a/src/access-broker.h
+++ b/src/access-broker.h
@@ -87,6 +87,7 @@ TSS2_RC            access_broker_context_saveflush      (AccessBroker *broker,
 TSS2_RC            access_broker_context_save           (AccessBroker *broker,
                                                          TPM_HANDLE    handle,
                                                          TPMS_CONTEXT *context);
+void               access_broker_flush_all_context      (AccessBroker *broker);
 
 G_END_DECLS
 

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -195,6 +195,9 @@ init_thread_func (gpointer user_data)
         tabrmd_critical ("TPM reports 0x%" PRIx32 " loaded transient objects, "
                          "aborting", loaded_trans_objs);
     }
+    if (data->options.flush_all) {
+        access_broker_flush_all_context (data->access_broker);
+    }
     /**
      * Instantiate and the objects that make up the TPM command processing
      * pipeline.
@@ -305,6 +308,9 @@ parse_opts (gint            argc,
         { "fail-on-loaded-trans", 'i', 0, G_OPTION_ARG_NONE,
           &options->fail_on_loaded_trans,
           "Fail initialization if the TPM reports loaded transient objects" },
+        { "flush-all", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+          &options->flush_all,
+          "Flush all objects and sessions from TPM on startup." },
         { "max-connections", 'c', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,
           &options->max_connections, "Maximum number of client connections." },
         { "max-transient-objects", 'r', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT,

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -60,6 +60,7 @@ typedef struct tabrmd_options {
     GBusType        bus;
     TctiOptions    *tcti_options;
     gboolean        fail_on_loaded_trans;
+    gboolean        flush_all;
     guint           max_connections;
     guint           max_transient_objects;
     gchar          *dbus_name;


### PR DESCRIPTION
This option causes the daemon to flush all transient objects, loaded
and active sessions from the TPM on startup. The purpose of this option
is to put the TPM into as much of a pristine state as we reasonably
can. We only flush tese particular handle type since they're the only
objects managed by the tabrmd.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>