### PR TITLE
[master] password-authorization.int: don't use platform hierarchy for the test

### DIFF
--- a/test/integration/password-authorization.int.c
+++ b/test/integration/password-authorization.int.c
@@ -96,13 +96,12 @@ CreatePasswordTestNV (TSS2_SYS_CONTEXT   *sapi_context,
     // Now set the attributes.
     publicInfo.t.nvPublic.attributes.TPMA_NV_AUTHREAD = 1;
     publicInfo.t.nvPublic.attributes.TPMA_NV_AUTHWRITE = 1;
-    publicInfo.t.nvPublic.attributes.TPMA_NV_PLATFORMCREATE = 1;
     publicInfo.t.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
     publicInfo.t.nvPublic.authPolicy.t.size = 0;
     publicInfo.t.nvPublic.dataSize = 32;
 
     rval = Tss2_Sys_NV_DefineSpace (sapi_context,
-                                    TPM_RH_PLATFORM,
+                                    TPM_RH_OWNER,
                                     &sessionsData,
                                     &nvAuth,
                                     &publicInfo,
@@ -220,7 +219,7 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 
     // Now undefine the index.
     rval = Tss2_Sys_NV_UndefineSpace (sapi_context,
-                                      TPM_RH_PLATFORM,
+                                      TPM_RH_OWNER,
                                       TPM20_INDEX_PASSWORD_TEST,
                                       &sessionsData,
                                       0);


### PR DESCRIPTION
Usually, platform hierarchy is intended to be locked and
controlled by OEM/ODM. In order to make the test usable on
all systems, including a real TPM hardware, use owner hierarchy
instead of platform hierarchy for the test.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>