### PR TITLE
[1.x] test: support to run the test on a real TPM hardware

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,8 @@ and executed.
 * cmocka unit test framework
 * Microsoft / IBM Software TPM2 simulator version 532 as packaged by IBM:
 https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
+* Alternately, run the test suite on a real TPM hardware, with a safety
+attention described below.
 
 # System User & Group
 As is common security practice we encourage *everyone* to run the `tpm2-abrmd`
@@ -184,6 +186,13 @@ $ ./configure --with-simulatorbin=/path/to/tpm_server
 If the configure script is able to find the executable you provide through this
 option then executing `make check` will cause the integration tests to be built
 and executed.
+
+If the executable is not found, or this option is not specified, the integration
+tests are assumed to be executed with a real TPM hardware.
+***** ATTENTION *****
+If this test suite is executed against a TPM it may cause damage to the TPM (NV
+storage and private key wear out etc).
+You have been warned.
 
 # Compilation
 Compiling the code requires running `make`. You may provide `make` whatever

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,10 +2,13 @@
 VPATH = $(srcdir) $(builddir)
 ACLOCAL_AMFLAGS = -I m4
 
-.PHONY: unit-count
+.PHONY: unit-count prompt-user$(EXEEXT)
 
 unit-count: check
 	sh scripts/unit-count.sh
+
+prompt-user$(EXEEXT):
+	sh scripts/prompt-user.sh
 
 AM_CFLAGS = $(EXTRA_CFLAGS) \
     -I$(srcdir)/src -I$(srcdir)/src/include -I$(builddir)/src \
@@ -46,7 +49,6 @@ if TCTI_SOCKET
 endif
 endif #UNIT
 
-if SIMULATOR_BIN
 TESTS_INTEGRATION = \
     test/integration/auth-session-max.int \
     test/integration/auth-session-start-flush.int \
@@ -65,7 +67,6 @@ TESTS_INTEGRATION = \
     test/integration/password-authorization.int \
     test/integration/tpm2-command-flush-no-handle.int \
     test/integration/util-buf-max-upper-bound.int
-endif
 
 XFAIL_TESTS = \
     test/integration/start-auth-session.int \
@@ -74,10 +75,18 @@ XFAIL_TESTS = \
 TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TEST_EXTENSIONS = .int
 INT_LOG_COMPILER = $(srcdir)/scripts/int-log-compiler.sh
+if SIMULATOR_BIN
 INT_LOG_FLAGS = --simulator-bin=$(SIMULATOR_BIN) --tabrmd-bin=$(sbin_PROGRAMS)
+else
+INT_LOG_FLAGS = --tabrmd-bin=$(sbin_PROGRAMS)
+endif #SIMULATOR_BIN
 
 sbin_PROGRAMS   = src/tpm2-abrmd
 check_PROGRAMS  = $(sbin_PROGRAMS) $(TESTS)
+if SIMULATOR_BIN
+else
+check_PROGRAMS += prompt-user$(EXEEXT)
+endif
 
 # libraries
 libtcti_tabrmd = src/libtcti-tabrmd.la

--- a/scripts/prompt-user.sh
+++ b/scripts/prompt-user.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This is a quick script that parses the log files from 'make check' to
+# extract the number of unit tests in each test binary. It keeps a running
+# total of the tests dumping this count to stdout before exiting.
+
+printf "\033[1;31m"
+echo "***********************************************************"
+echo "                         ATTENTION"
+echo "If this test suite is executed against a TPM it may cause"
+echo "damage to the TPM (NV storage and private key wear out etc)."
+echo
+echo "***********************************************************"
+printf "\033[0m"
+
+while [ : ]; do
+    read -p "Do you wish to continue? [Y/n] " -n 1 REPLY
+    echo
+
+    if [ x"${REPLY}" = x"Y" ]; then
+        echo "Integration tests confirmed"
+        exit 0
+    elif [ x"${REPLY}" = x"n" ]; then
+        echo "Integration tests canceled"
+        exit 1
+    else
+        echo "Press 'Y' to continie, and 'n' to cancel"
+    fi
+done


### PR DESCRIPTION
This change allows to run the integration test on a real TPM hardware
via specifying --enable-unit only. In addition, the end user must be
prompted with a highlight warning to understand the risk if continue.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>