### PR TITLE
test: Remove sapi_fini_from_opts function from context-util module.

### DIFF
--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -36,8 +36,6 @@
 
 #include "context-util.h"
 
-#include "common.h"
-
 /*
  * Initialize a TSS2_TCTI_CONTEXT for the device TCTI.
  */
@@ -212,20 +210,6 @@ sapi_init_from_opts (test_opts_t *options)
     if (sapi_ctx == NULL)
         return NULL;
     return sapi_ctx;
-}
-/*
- * Initialize a SAPI context used to clean up all unused contexts.
- */
-void
-sapi_fini_from_opts (test_opts_t *options)
-{
-    TSS2_SYS_CONTEXT *sapi_ctx;
-
-    sapi_ctx = sapi_init_from_opts (options);
-    if (sapi_ctx == NULL)
-        exit (1);
-    clean_up_all (sapi_ctx);
-    sapi_teardown_full (sapi_ctx);
 }
 /*
  * Initialize a TSS2_TCTI_CONTEXT using whatever TCTI data is in the options

--- a/test/integration/context-util.h
+++ b/test/integration/context-util.h
@@ -39,7 +39,6 @@ TSS2_TCTI_CONTEXT*    tcti_socket_init    (char const         *address,
                                            uint16_t            port);
 TSS2_TCTI_CONTEXT*    tcti_init_from_opts (test_opts_t        *options);
 TSS2_SYS_CONTEXT*     sapi_init_from_opts (test_opts_t        *options);
-void                  sapi_fini_from_opts (test_opts_t        *options);
 void                  sapi_teardown_full  (TSS2_SYS_CONTEXT   *sapi_context);
 
 #endif /* CONTEXT_UTIL_H */

--- a/test/integration/main.c
+++ b/test/integration/main.c
@@ -27,6 +27,7 @@
 #include <glib.h>
 #include <stdbool.h>
 
+#include "common.h"
 #include "tcti-tabrmd.h"
 #include "test.h"
 #include "test-options.h"
@@ -67,12 +68,14 @@ main (int   argc,
     ret = test_invoke (sapi_context);
     sapi_teardown_full (sapi_context);
     /*
-     * Certain testcase, e.g, tcti-cancel, may corrupt the state of tcti
-     * context, and thus causes 0xa0007 error code if directly cleaning up
-     * the contexts under the current sapi context. Therefore, we intend to
-     * launch a new sapi and tcti contexts to do the cleanup in order to
-     * avoid the violation caused by the previous mess.
+     * Use new SAPI & TCTI to clean out TPM after test. Test code may have
+     * left either in an unusable state.
      */
-    sapi_fini_from_opts (&opts);
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL) {
+        exit (1);
+    }
+    clean_up_all (sapi_context);
+    sapi_teardown_full (sapi_context);
     return ret;
 }


### PR DESCRIPTION
Normally wrapping this functionality in a function would make sense but
doing so here causes an unwanted dependency from the context-util module
to the common module. This function is only called from the integration
test driver so it's easier and more clear when we  just call the ~3
functions from the integration test driver directly.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>