### PR TITLE
test: correct the property name to be queried

### DIFF
--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -403,9 +403,13 @@ clean_up_all (TSS2_SYS_CONTEXT *sapi_context)
             .count = MAX_CAP_HANDLES,
         },
         {
-            .property = POLICY_SESSION_FIRST,
+            .property = LOADED_SESSION_FIRST,
             .count = MAX_CAP_HANDLES,
         },
+        {
+            .property = ACTIVE_SESSION_FIRST,
+            .count = MAX_CAP_HANDLES,
+        }
     };
 
     for (i = 0; i < sizeof(properties) / sizeof(struct property_info); ++i) {


### PR DESCRIPTION
According to the spec, TPM_HT_LOADED_SESSION and TPM_HT_HMAC_SESSION
have the same value, as do TPM_HT_SAVED_SESSION and
TPM_HT_POLICY_SESSION, but they are used in different context. In
the context of TPM2_GetCapability, LOADED_SESSION_FIRST should be
used instead of POLICY_SESSION_FIRST.

In addition, there is no SAVED_SESSION_FIRST in the spec, so use
ACTIVE_SESSION_FIRST for the query instead .

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>